### PR TITLE
moved getSavedDatafile to the DatafileManager protocol

### DIFF
--- a/OptimizelySDKDatafileManager/OptimizelySDKDatafileManager/OPTLYDatafileManager.m
+++ b/OptimizelySDKDatafileManager/OptimizelySDKDatafileManager/OPTLYDatafileManager.m
@@ -92,7 +92,6 @@ NSTimeInterval const kDefaultDatafileFetchInterval_s = 120;
                                  else if (statusCode == 304) {
                                      logMessage = [NSString stringWithFormat:OPTLYLoggerMessagesDatafileManagerDatafileNotDownloadedNoChanges, projectId];
                                      [self.logger logMessage:logMessage withLevel:OptimizelyLogLevelDebug];
-                                     data = [self getSavedDatafile];
                                  }
                                  else {
                                      // TODO: Josh W. handle bad response

--- a/OptimizelySDKShared/OptimizelySDKShared/OPTLYDatafileManager.h
+++ b/OptimizelySDKShared/OptimizelySDKShared/OPTLYDatafileManager.h
@@ -21,6 +21,13 @@
 @protocol OPTLYDatafileManager <NSObject>
 
 /**
+ * Retrieve the datafile that is currently saved on the device.
+ * @return NSData object that should be the most recently downloaded datafile.
+ *      Will be nil if no datafile has been successfully downloaded.
+ */
+- (NSData *)getSavedDatafile;
+
+/**
  * Download the datafile for the project ID
  * @param projectId The project ID of the datafile to request.
  * @param completion Completion handler.

--- a/OptimizelySDKShared/OptimizelySDKShared/OPTLYManager.m
+++ b/OptimizelySDKShared/OptimizelySDKShared/OPTLYManager.m
@@ -98,6 +98,9 @@
 
 - (void)initializeClientWithCallback:(void (^)(NSError * _Nullable, OPTLYClient * _Nullable))callback {
     [self.datafileManager downloadDatafile:self.projectId completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        if ([(NSHTTPURLResponse *)response statusCode] == 304) {
+            data = [self.datafileManager getSavedDatafile];
+        }
         if (!error) {
             OPTLYClient *client = [self initializeClientWithManagerSettingsAndDatafile:data];
             if (client.optimizely) {


### PR DESCRIPTION
If the response from the download datafile is a 304, we will get the saved datafile in the OPTLYManager's initialization and not replace it in the datafile manager callback