### PR TITLE
Change live variable getter methods' signatures regarding `activateExperiments`

### DIFF
--- a/OptimizelySDKCore/OptimizelySDKCore/Optimizely.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/Optimizely.h
@@ -135,6 +135,20 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
  *
  * @param variableKey The name of the live variable
  * @param userId The user ID
+ * @return The string value for the live variable.
+ *  If no matching variable key is found, then default value is returned if it exists. Otherwise, nil is returned.
+ *  If an error is found, a warning message is logged, and an error will be propagated to the error handler.
+ */
+- (nullable NSString *)getVariableString:(nonnull NSString *)variableKey
+                                  userId:(nonnull NSString *)userId;
+
+/**
+ * Gets the string value of the live variable.
+ * The value is cached when client is initialized
+ * and is not refreshed until re-initialization.
+ *
+ * @param variableKey The name of the live variable
+ * @param userId The user ID
  * @param activateExperiments Indicates if the experiment(s) should be activated
  * @return The string value for the live variable.
  *  If no matching variable key is found, then default value is returned if it exists. Otherwise, nil is returned.
@@ -182,6 +196,20 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
                               attributes:(nullable NSDictionary *)attributes
                      activateExperiments:(bool)activateExperiments
                                    error:(NSError * _Nullable * _Nullable)error;
+
+/**
+ * Gets the boolean value of the live variable.
+ * The value is cached when client is initialized
+ * and is not refreshed until re-initialization.
+ *
+ * @param variableKey The name of the live variable boolean
+ * @param userId The user ID
+ * @return The boolean value for the live variable.
+ *  If no matching variable key is found, then default value is returned if it exists. Otherwise, false is returned.
+ *  If an error is found, a warning message is logged, and an error will be propagated to the error handler.
+ */
+- (BOOL)getVariableBool:(nonnull NSString *)variableKey
+                 userId:(nonnull NSString *)userId;
 
 /**
  * Gets the boolean value of the live variable.
@@ -246,6 +274,20 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
  *
  * @param variableKey The name of the live variable number
  * @param userId The user ID
+ * @return The number value for the live variable.
+ *  If no matching variable key is found, then default value is returned if it exists. Otherwise, 0 is returned.
+ *  If an error is found, a warning message is logged, and an error will be propagated to the error handler.
+ */
+- (int)getVariableInteger:(nonnull NSString *)variableKey
+                   userId:(nonnull NSString *)userId;
+
+/**
+ * Gets the integer value of the live variable.
+ * The value is cached when client is initialized
+ * and is not refreshed until re-initialization.
+ *
+ * @param variableKey The name of the live variable number
+ * @param userId The user ID
  * @param activateExperiments Indicates if the experiment(s) should be activated
  * @return The number value for the live variable.
  *  If no matching variable key is found, then default value is returned if it exists. Otherwise, 0 is returned.
@@ -293,6 +335,20 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
                attributes:(nullable NSDictionary *)attributes
       activateExperiments:(bool)activateExperiments
                     error:(NSError * _Nullable * _Nullable)error;
+
+/**
+ * Gets the float value of the live variable.
+ * The value is cached when client is initialized
+ * and is not refreshed until re-initialization.
+ *
+ * @param variableKey The name of the live variable number
+ * @param userId The user ID
+ * @return The number value for the live variable.
+ *  If no matching variable key is found, then default value is returned if it exists. Otherwise, 0.0 is returned.
+ *  If an error is found, a warning message is logged, and an error will be propagated to the error handler.
+ */
+- (double)getVariableFloat:(nonnull NSString *)variableKey
+                    userId:(nonnull NSString *)userId;
 
 /**
  * Gets the float value of the live variable.

--- a/OptimizelySDKCore/OptimizelySDKCore/Optimizely.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/Optimizely.h
@@ -208,8 +208,8 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
  *  If no matching variable key is found, then default value is returned if it exists. Otherwise, false is returned.
  *  If an error is found, a warning message is logged, and an error will be propagated to the error handler.
  */
-- (BOOL)getVariableBool:(nonnull NSString *)variableKey
-                 userId:(nonnull NSString *)userId;
+- (BOOL)getVariableBoolean:(nonnull NSString *)variableKey
+                    userId:(nonnull NSString *)userId;
 
 /**
  * Gets the boolean value of the live variable.
@@ -223,9 +223,9 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
  *  If no matching variable key is found, then default value is returned if it exists. Otherwise, false is returned.
  *  If an error is found, a warning message is logged, and an error will be propagated to the error handler.
  */
-- (BOOL)getVariableBool:(nonnull NSString *)variableKey
-                 userId:(nonnull NSString *)userId
-    activateExperiments:(bool)activateExperiments;
+- (BOOL)getVariableBoolean:(nonnull NSString *)variableKey
+                    userId:(nonnull NSString *)userId
+       activateExperiments:(bool)activateExperiments;
 
 /**
  * Gets the boolean value of the live variable.
@@ -240,10 +240,10 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
  *  If no matching variable key is found, then default value is returned if it exists. Otherwise, false is returned.
  *  If an error is found, a warning message is logged, and an error will be propagated to the error handler.
  */
-- (BOOL)getVariableBool:(nonnull NSString *)variableKey
-                 userId:(nonnull NSString *)userId
-             attributes:(nullable NSDictionary *)attributes
-    activateExperiments:(bool)activateExperiments;
+- (BOOL)getVariableBoolean:(nonnull NSString *)variableKey
+                    userId:(nonnull NSString *)userId
+                attributes:(nullable NSDictionary *)attributes
+       activateExperiments:(bool)activateExperiments;
 
 /**
  * Gets the boolean value of the live variable.
@@ -260,11 +260,11 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
  *  If no matching variable key is found, then default value is returned if it exists. Otherwise, false is returned.
  *  If an error is found, a warning message is logged, and an error will be propagated to the user.
  */
-- (BOOL)getVariableBool:(nonnull NSString *)variableKey
-                 userId:(nonnull NSString *)userId
-             attributes:(nullable NSDictionary *)attributes
-    activateExperiments:(bool)activateExperiments
-                  error:(NSError * _Nullable * _Nullable)error;
+- (BOOL)getVariableBoolean:(nonnull NSString *)variableKey
+                    userId:(nonnull NSString *)userId
+                attributes:(nullable NSDictionary *)attributes
+       activateExperiments:(bool)activateExperiments
+                     error:(NSError * _Nullable * _Nullable)error;
 
 
 /**

--- a/OptimizelySDKCore/OptimizelySDKCore/Optimizely.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/Optimizely.h
@@ -134,35 +134,15 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
  * and is not refreshed until re-initialization.
  *
  * @param variableKey The name of the live variable
- * @param activateExperiments Indicates if the experiment(s) should be activated
  * @param userId The user ID
- *  - OPTLYLiveVariableErrorKeyUnknown - key does not exist
+ * @param activateExperiments Indicates if the experiment(s) should be activated
  * @return The string value for the live variable.
  *  If no matching variable key is found, then default value is returned if it exists. Otherwise, nil is returned.
  *  If an error is found, a warning message is logged, and an error will be propagated to the error handler.
  */
 - (nullable NSString *)getVariableString:(nonnull NSString *)variableKey
-                     activateExperiments:(bool)activateExperiments
-                                  userId:(nonnull NSString *)userId;
-
-/**
- * Gets the string value of the live variable.
- * The value is cached when client is initialized
- * and is not refreshed until re-initialization.
- *
- * @param variableKey The name of the live variable
- * @param activateExperiments Indicates if the experiment(s) should be activated
- * @param userId The user ID
- * @param attributes A map of attribute names to current user attribute values
- *  - OPTLYLiveVariableErrorKeyUnknown - key does not exist
- * @return The string value for the live variable.
- *  If no matching variable key is found, then default value is returned if it exists. Otherwise, nil is returned.
- *  If an error is found, a warning message is logged, and an error will be propagated to the error handler.
- */
-- (nullable NSString *)getVariableString:(nonnull NSString *)variableKey
-                     activateExperiments:(bool)activateExperiments
                                   userId:(nonnull NSString *)userId
-                              attributes:(nullable NSDictionary *)attributes;
+                     activateExperiments:(bool)activateExperiments;
 
 /**
  * Gets the string value of the live variable.
@@ -170,9 +150,27 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
  * and is not refreshed until re-initialization.
  *
  * @param variableKey The name of the live variable
- * @param activateExperiments Indicates if the experiment(s) should be activated
  * @param userId The user ID
  * @param attributes A map of attribute names to current user attribute values
+ * @param activateExperiments Indicates if the experiment(s) should be activated
+ * @return The string value for the live variable.
+ *  If no matching variable key is found, then default value is returned if it exists. Otherwise, nil is returned.
+ *  If an error is found, a warning message is logged, and an error will be propagated to the error handler.
+ */
+- (nullable NSString *)getVariableString:(nonnull NSString *)variableKey
+                                  userId:(nonnull NSString *)userId
+                              attributes:(nullable NSDictionary *)attributes
+                     activateExperiments:(bool)activateExperiments;
+
+/**
+ * Gets the string value of the live variable.
+ * The value is cached when client is initialized
+ * and is not refreshed until re-initialization.
+ *
+ * @param variableKey The name of the live variable
+ * @param userId The user ID
+ * @param attributes A map of attribute names to current user attribute values
+ * @param activateExperiments Indicates if the experiment(s) should be activated
  * @param error An error value if the value is not valid for the following reasons:
  *  - OPTLYLiveVariableErrorKeyUnknown - key does not exist
  * @return The string value for the live variable.
@@ -180,9 +178,9 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
  *  If an error is found, a warning message is logged, and an error will be propagated to the user.
  */
 - (nullable NSString *)getVariableString:(nonnull NSString *)variableKey
-                     activateExperiments:(bool)activateExperiments
                                   userId:(nonnull NSString *)userId
                               attributes:(nullable NSDictionary *)attributes
+                     activateExperiments:(bool)activateExperiments
                                    error:(NSError * _Nullable * _Nullable)error;
 
 /**
@@ -191,35 +189,15 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
  * and is not refreshed until re-initialization.
  *
  * @param variableKey The name of the live variable boolean
- * @param activateExperiments Indicates if the experiment(s) should be activated
  * @param userId The user ID
- *  - OPTLYLiveVariableErrorKeyUnknown - key does not exist
+ * @param activateExperiments Indicates if the experiment(s) should be activated
  * @return The boolean value for the live variable.
  *  If no matching variable key is found, then default value is returned if it exists. Otherwise, false is returned.
  *  If an error is found, a warning message is logged, and an error will be propagated to the error handler.
  */
 - (BOOL)getVariableBool:(nonnull NSString *)variableKey
-    activateExperiments:(bool)activateExperiments
-                 userId:(nonnull NSString *)userId;
-
-/**
- * Gets the boolean value of the live variable.
- * The value is cached when client is initialized
- * and is not refreshed until re-initialization.
- *
- * @param variableKey The name of the live variable boolean
- * @param activateExperiments Indicates if the experiment(s) should be activated
- * @param userId The user ID
- * @param attributes A map of attribute names to current user attribute values
- *  - OPTLYLiveVariableErrorKeyUnknown - key does not exist
- * @return The boolean value for the live variable.
- *  If no matching variable key is found, then default value is returned if it exists. Otherwise, false is returned.
- *  If an error is found, a warning message is logged, and an error will be propagated to the error handler.
- */
-- (BOOL)getVariableBool:(nonnull NSString *)variableKey
-    activateExperiments:(bool)activateExperiments
                  userId:(nonnull NSString *)userId
-             attributes:(nullable NSDictionary *)attributes;
+    activateExperiments:(bool)activateExperiments;
 
 /**
  * Gets the boolean value of the live variable.
@@ -227,9 +205,27 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
  * and is not refreshed until re-initialization.
  *
  * @param variableKey The name of the live variable boolean
- * @param activateExperiments Indicates if the experiment(s) should be activated
  * @param userId The user ID
  * @param attributes A map of attribute names to current user attribute values
+ * @param activateExperiments Indicates if the experiment(s) should be activated
+ * @return The boolean value for the live variable.
+ *  If no matching variable key is found, then default value is returned if it exists. Otherwise, false is returned.
+ *  If an error is found, a warning message is logged, and an error will be propagated to the error handler.
+ */
+- (BOOL)getVariableBool:(nonnull NSString *)variableKey
+                 userId:(nonnull NSString *)userId
+             attributes:(nullable NSDictionary *)attributes
+    activateExperiments:(bool)activateExperiments;
+
+/**
+ * Gets the boolean value of the live variable.
+ * The value is cached when client is initialized
+ * and is not refreshed until re-initialization.
+ *
+ * @param variableKey The name of the live variable boolean
+ * @param userId The user ID
+ * @param attributes A map of attribute names to current user attribute values
+ * @param activateExperiments Indicates if the experiment(s) should be activated
  * @param error An error value if the value is not valid for the following reasons:
  *  - OPTLYLiveVariableErrorKeyUnknown - key does not exist
  * @return The boolean value for the live variable.
@@ -237,9 +233,9 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
  *  If an error is found, a warning message is logged, and an error will be propagated to the user.
  */
 - (BOOL)getVariableBool:(nonnull NSString *)variableKey
-    activateExperiments:(bool)activateExperiments
                  userId:(nonnull NSString *)userId
              attributes:(nullable NSDictionary *)attributes
+    activateExperiments:(bool)activateExperiments
                   error:(NSError * _Nullable * _Nullable)error;
 
 
@@ -249,35 +245,15 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
  * and is not refreshed until re-initialization.
  *
  * @param variableKey The name of the live variable number
- * @param activateExperiments Indicates if the experiment(s) should be activated
  * @param userId The user ID
- *  - OPTLYLiveVariableErrorKeyUnknown - key does not exist
+ * @param activateExperiments Indicates if the experiment(s) should be activated
  * @return The number value for the live variable.
  *  If no matching variable key is found, then default value is returned if it exists. Otherwise, 0 is returned.
  *  If an error is found, a warning message is logged, and an error will be propagated to the error handler.
  */
 - (int)getVariableInteger:(nonnull NSString *)variableKey
-      activateExperiments:(bool)activateExperiments
-                   userId:(nonnull NSString *)userId;
-
-/**
- * Gets the integer value of the live variable.
- * The value is cached when client is initialized
- * and is not refreshed until re-initialization.
- *
- * @param variableKey The name of the live variable number
- * @param activateExperiments Indicates if the experiment(s) should be activated
- * @param userId The user ID
- * @param attributes A map of attribute names to current user attribute values
- *  - OPTLYLiveVariableErrorKeyUnknown - key does not exist
- * @return The number value for the live variable.
- *  If no matching variable key is found, then default value is returned if it exists. Otherwise, 0 is returned.
- *  If an error is found, a warning message is logged, and an error will be propagated to the error handler.
- */
-- (int)getVariableInteger:(nonnull NSString *)variableKey
-      activateExperiments:(bool)activateExperiments
                    userId:(nonnull NSString *)userId
-               attributes:(nullable NSDictionary *)attributes;
+      activateExperiments:(bool)activateExperiments;
 
 /**
  * Gets the integer value of the live variable.
@@ -285,9 +261,27 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
  * and is not refreshed until re-initialization.
  *
  * @param variableKey The name of the live variable number
- * @param activateExperiments Indicates if the experiment(s) should be activated
  * @param userId The user ID
  * @param attributes A map of attribute names to current user attribute values
+ * @param activateExperiments Indicates if the experiment(s) should be activated
+ * @return The number value for the live variable.
+ *  If no matching variable key is found, then default value is returned if it exists. Otherwise, 0 is returned.
+ *  If an error is found, a warning message is logged, and an error will be propagated to the error handler.
+ */
+- (int)getVariableInteger:(nonnull NSString *)variableKey
+                   userId:(nonnull NSString *)userId
+               attributes:(nullable NSDictionary *)attributes
+      activateExperiments:(bool)activateExperiments;
+
+/**
+ * Gets the integer value of the live variable.
+ * The value is cached when client is initialized
+ * and is not refreshed until re-initialization.
+ *
+ * @param variableKey The name of the live variable number
+ * @param userId The user ID
+ * @param attributes A map of attribute names to current user attribute values
+ * @param activateExperiments Indicates if the experiment(s) should be activated
  * @param error An error value if the value is not valid for the following reasons:
  *  - OPTLYLiveVariableErrorKeyUnknown - key does not exist
  * @return The number value for the live variable.
@@ -295,9 +289,9 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
  *  If an error is found, a warning message is logged, and an error will be propagated to the user.
  */
 - (int)getVariableInteger:(nonnull NSString *)variableKey
-      activateExperiments:(bool)activateExperiments
-                    userId:(nonnull NSString *)userId
+                   userId:(nonnull NSString *)userId
                attributes:(nullable NSDictionary *)attributes
+      activateExperiments:(bool)activateExperiments
                     error:(NSError * _Nullable * _Nullable)error;
 
 /**
@@ -306,35 +300,15 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
  * and is not refreshed until re-initialization.
  *
  * @param variableKey The name of the live variable number
- * @param activateExperiments Indicates if the experiment(s) should be activated
  * @param userId The user ID
- *  - OPTLYLiveVariableErrorKeyUnknown - key does not exist
+ * @param activateExperiments Indicates if the experiment(s) should be activated
  * @return The number value for the live variable.
  *  If no matching variable key is found, then default value is returned if it exists. Otherwise, 0.0 is returned.
  *  If an error is found, a warning message is logged, and an error will be propagated to the error handler.
  */
 - (double)getVariableFloat:(nonnull NSString *)variableKey
-       activateExperiments:(bool)activateExperiments
-                    userId:(nonnull NSString *)userId;
-
-/**
- * Gets the float value of the live variable.
- * The value is cached when client is initialized
- * and is not refreshed until re-initialization.
- *
- * @param variableKey The name of the live variable number
- * @param activateExperiments Indicates if the experiment(s) should be activated
- * @param userId The user ID
- * @param attributes A map of attribute names to current user attribute values
- *  - OPTLYLiveVariableErrorKeyUnknown - key does not exist
- * @return The number value for the live variable.
- *  If no matching variable key is found, then default value is returned if it exists. Otherwise, 0.0 is returned.
- *  If an error is found, a warning message is logged, and an error will be propagated to the error handler.
- */
-- (double)getVariableFloat:(nonnull NSString *)variableKey
-       activateExperiments:(bool)activateExperiments
                     userId:(nonnull NSString *)userId
-                attributes:(nullable NSDictionary *)attributes;
+       activateExperiments:(bool)activateExperiments;
 
 /**
  * Gets the float value of the live variable.
@@ -342,9 +316,27 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
  * and is not refreshed until re-initialization.
  *
  * @param variableKey The name of the live variable number
- * @param activateExperiments Indicates if the experiment(s) should be activated
  * @param userId The user ID
  * @param attributes A map of attribute names to current user attribute values
+ * @param activateExperiments Indicates if the experiment(s) should be activated
+ * @return The number value for the live variable.
+ *  If no matching variable key is found, then default value is returned if it exists. Otherwise, 0.0 is returned.
+ *  If an error is found, a warning message is logged, and an error will be propagated to the error handler.
+ */
+- (double)getVariableFloat:(nonnull NSString *)variableKey
+                    userId:(nonnull NSString *)userId
+                attributes:(nullable NSDictionary *)attributes
+       activateExperiments:(bool)activateExperiments;
+
+/**
+ * Gets the float value of the live variable.
+ * The value is cached when client is initialized
+ * and is not refreshed until re-initialization.
+ *
+ * @param variableKey The name of the live variable number
+ * @param userId The user ID
+ * @param attributes A map of attribute names to current user attribute values
+ * @param activateExperiments Indicates if the experiment(s) should be activated
  * @param error An error value if the value is not valid for the following reasons:
  *  - OPTLYLiveVariableErrorKeyUnknown - key does not exist
  * @return The number value for the live variable.
@@ -352,9 +344,9 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
  *  If an error is found, a warning message is logged, and an error will be propagated to the user.
  */
 - (double)getVariableFloat:(nonnull NSString *)variableKey
-       activateExperiments:(bool)activateExperiments
                     userId:(nonnull NSString *)userId
                 attributes:(nullable NSDictionary *)attributes
+       activateExperiments:(bool)activateExperiments
                      error:(NSError * _Nullable * _Nullable)error;
 
 @end

--- a/OptimizelySDKCore/OptimizelySDKCore/Optimizely.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/Optimizely.m
@@ -308,6 +308,15 @@ static NSString *const kValue = @"value";
 }
 
 - (nullable NSString *)getVariableString:(NSString *)variableKey
+                                  userId:(NSString *)userId {
+    return [self getVariableString:variableKey
+                            userId:userId
+                        attributes:nil
+               activateExperiments:NO
+                             error:nil];
+}
+
+- (nullable NSString *)getVariableString:(NSString *)variableKey
                                   userId:(NSString *)userId
                      activateExperiments:(bool)activateExperiments {
     return [self getVariableString:variableKey
@@ -384,6 +393,15 @@ static NSString *const kValue = @"value";
 }
 
 - (BOOL)getVariableBool:(NSString *)variableKey
+                 userId:(NSString *)userId {
+    return [self getVariableBool:variableKey
+                          userId:userId
+                      attributes:nil
+             activateExperiments:NO
+                           error:nil];
+}
+
+- (BOOL)getVariableBool:(NSString *)variableKey
                  userId:(NSString *)userId
     activateExperiments:(bool)activateExperiments {
     return [self getVariableBool:variableKey
@@ -424,6 +442,15 @@ static NSString *const kValue = @"value";
 }
 
 - (int)getVariableInteger:(NSString *)variableKey
+                   userId:(NSString *)userId {
+    return [self getVariableInteger:variableKey
+                             userId:userId
+                         attributes:nil
+                activateExperiments:NO
+                              error:nil];
+}
+
+- (int)getVariableInteger:(NSString *)variableKey
                    userId:(NSString *)userId
       activateExperiments:(bool)activateExperiments {
     return [self getVariableInteger:variableKey
@@ -461,6 +488,15 @@ static NSString *const kValue = @"value";
     }
     
     return variableValue;
+}
+
+- (double)getVariableFloat:(NSString *)variableKey
+                    userId:(NSString *)userId {
+    return [self getVariableFloat:variableKey
+                           userId:userId
+                       attributes:nil
+              activateExperiments:NO
+                            error:nil];
 }
 
 - (double)getVariableFloat:(NSString *)variableKey

--- a/OptimizelySDKCore/OptimizelySDKCore/Optimizely.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/Optimizely.m
@@ -265,15 +265,15 @@ static NSString *const kValue = @"value";
  * Buckets user into a variation of the provided experiment.
  *
  * @param experimentKey Key of experiment that user is being bucketed into
- * @param activateExperiments Indicates if the user should be activated into the experiment
  * @param userId The user ID
  * @param attributes A map of attribute names to current user attribute values
+ * @param activateExperiments Indicates if the user should be activated into the experiment
  * @return Variation of the experiment that the user has been bucketed into
  */
 - (OPTLYVariation *)getVariationForExperiment:(NSString *)experimentKey
-                          activateExperiments:(bool)activateExperiments
                                        userId:(nonnull NSString *)userId
-                                   attributes:(nullable NSDictionary *)attributes {
+                                   attributes:(nullable NSDictionary *)attributes
+                          activateExperiments:(bool)activateExperiments {
     OPTLYVariation *variation = nil;
     if (activateExperiments) {
         variation = [self activateExperiment:experimentKey
@@ -308,30 +308,30 @@ static NSString *const kValue = @"value";
 }
 
 - (nullable NSString *)getVariableString:(NSString *)variableKey
-                     activateExperiments:(bool)activateExperiments
-                                  userId:(NSString *)userId {
+                                  userId:(NSString *)userId
+                     activateExperiments:(bool)activateExperiments {
     return [self getVariableString:variableKey
-                                 activateExperiments:activateExperiments
-                                              userId:userId
-                                          attributes:nil
-                                               error:nil];
+                            userId:userId
+                        attributes:nil
+               activateExperiments:activateExperiments
+                             error:nil];
 }
 
 - (nullable NSString *)getVariableString:(NSString *)variableKey
-                     activateExperiments:(bool)activateExperiments
                                   userId:(NSString *)userId
-                              attributes:(nullable NSDictionary *)attributes {
+                              attributes:(nullable NSDictionary *)attributes
+                     activateExperiments:(bool)activateExperiments {
     return [self getVariableString:variableKey
-               activateExperiments:activateExperiments
                             userId:userId
                         attributes:attributes
+               activateExperiments:activateExperiments
                              error:nil];
 }
 
 - (nullable NSString *)getVariableString:(nonnull NSString *)variableKey
-                     activateExperiments:(bool)activateExperiments
                                   userId:(nonnull NSString *)userId
                               attributes:(nullable NSDictionary *)attributes
+                     activateExperiments:(bool)activateExperiments
                                    error:(NSError * _Nullable * _Nullable)error {
     OPTLYVariable *variable = [self.config getVariableForVariableKey:variableKey];
     
@@ -365,9 +365,9 @@ static NSString *const kValue = @"value";
     
     for (NSString *experimentKey in experimentKeysForLiveVariable) {
         OPTLYVariation *variation = [self getVariationForExperiment:experimentKey
-                                                activateExperiments:activateExperiments
                                                              userId:userId
-                                                         attributes:attributes];
+                                                         attributes:attributes
+                                                activateExperiments:activateExperiments];
         
         if (variation == nil) {
             // If user is not bucketed into experiment, then continue to another experiment
@@ -384,36 +384,36 @@ static NSString *const kValue = @"value";
 }
 
 - (BOOL)getVariableBool:(NSString *)variableKey
-    activateExperiments:(bool)activateExperiments
-                 userId:(NSString *)userId {
+                 userId:(NSString *)userId
+    activateExperiments:(bool)activateExperiments {
     return [self getVariableBool:variableKey
-             activateExperiments:activateExperiments
                           userId:userId
                       attributes:nil
+             activateExperiments:activateExperiments
                            error:nil];
 }
 
 - (BOOL)getVariableBool:(NSString *)variableKey
-    activateExperiments:(bool)activateExperiments
                  userId:(NSString *)userId
-             attributes:(nullable NSDictionary *)attributes {
+             attributes:(nullable NSDictionary *)attributes
+    activateExperiments:(bool)activateExperiments {
     return [self getVariableBool:variableKey
-             activateExperiments:activateExperiments
                           userId:userId
                       attributes:attributes
+             activateExperiments:activateExperiments
                            error:nil];
 }
 
 - (BOOL)getVariableBool:(nonnull NSString *)variableKey
-    activateExperiments:(bool)activateExperiments
                  userId:(nonnull NSString *)userId
              attributes:(nullable NSDictionary *)attributes
+    activateExperiments:(bool)activateExperiments
                   error:(NSError * _Nullable * _Nullable)error {
     BOOL variableValue = false;
     NSString *variableValueStringOrNil = [self getVariableString:variableKey
-                                             activateExperiments:activateExperiments
                                                           userId:userId
                                                       attributes:attributes
+                                             activateExperiments:activateExperiments
                                                            error:error];
     
     if (variableValueStringOrNil != nil) {
@@ -424,36 +424,36 @@ static NSString *const kValue = @"value";
 }
 
 - (int)getVariableInteger:(NSString *)variableKey
-      activateExperiments:(bool)activateExperiments
-                   userId:(NSString *)userId {
+                   userId:(NSString *)userId
+      activateExperiments:(bool)activateExperiments {
     return [self getVariableInteger:variableKey
-                activateExperiments:activateExperiments
                              userId:userId
                          attributes:nil
+                activateExperiments:activateExperiments
                               error:nil];
 }
 
 - (int)getVariableInteger:(NSString *)variableKey
-      activateExperiments:(bool)activateExperiments
                    userId:(NSString *)userId
-               attributes:(nullable NSDictionary *)attributes {
+               attributes:(nullable NSDictionary *)attributes
+      activateExperiments:(bool)activateExperiments {
     return [self getVariableInteger:variableKey
-                activateExperiments:activateExperiments
                              userId:userId
                          attributes:attributes
+                activateExperiments:activateExperiments
                               error:nil];
 }
 
 - (int)getVariableInteger:(nonnull NSString *)variableKey
-      activateExperiments:(bool)activateExperiments
                     userId:(nonnull NSString *)userId
                attributes:(nullable NSDictionary *)attributes
+      activateExperiments:(bool)activateExperiments
                     error:(NSError * _Nullable * _Nullable)error {
     int variableValue = 0;
     NSString *variableValueStringOrNil = [self getVariableString:variableKey
-                                             activateExperiments:activateExperiments
                                                           userId:userId
                                                       attributes:attributes
+                                             activateExperiments:activateExperiments
                                                            error:error];
     
     if (variableValueStringOrNil != nil) {
@@ -464,36 +464,36 @@ static NSString *const kValue = @"value";
 }
 
 - (double)getVariableFloat:(NSString *)variableKey
-       activateExperiments:(bool)activateExperiments
-                    userId:(NSString *)userId {
+                    userId:(NSString *)userId
+       activateExperiments:(bool)activateExperiments {
     return [self getVariableFloat:variableKey
-              activateExperiments:activateExperiments
                            userId:userId
                        attributes:nil
+              activateExperiments:activateExperiments
                             error:nil];
 }
 
 - (double)getVariableFloat:(NSString *)variableKey
-       activateExperiments:(bool)activateExperiments
                     userId:(NSString *)userId
-                attributes:(nullable NSDictionary *)attributes {
+                attributes:(nullable NSDictionary *)attributes
+       activateExperiments:(bool)activateExperiments {
     return [self getVariableFloat:variableKey
-              activateExperiments:activateExperiments
                            userId:userId
                        attributes:attributes
+              activateExperiments:activateExperiments
                             error:nil];
 }
 
 - (double)getVariableFloat:(nonnull NSString *)variableKey
-       activateExperiments:(bool)activateExperiments
                     userId:(nonnull NSString *)userId
                 attributes:(nullable NSDictionary *)attributes
+       activateExperiments:(bool)activateExperiments
                      error:(NSError * _Nullable * _Nullable)error {
     double variableValue = 0.0;
     NSString *variableValueStringOrNil = [self getVariableString:variableKey
-                                             activateExperiments:activateExperiments
                                                           userId:userId
                                                       attributes:attributes
+                                             activateExperiments:activateExperiments
                                                            error:error];
     
     if (variableValueStringOrNil != nil) {

--- a/OptimizelySDKCore/OptimizelySDKCore/Optimizely.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/Optimizely.m
@@ -392,41 +392,41 @@ static NSString *const kValue = @"value";
     return variable.defaultValue;
 }
 
-- (BOOL)getVariableBool:(NSString *)variableKey
-                 userId:(NSString *)userId {
-    return [self getVariableBool:variableKey
-                          userId:userId
-                      attributes:nil
-             activateExperiments:NO
-                           error:nil];
+- (BOOL)getVariableBoolean:(NSString *)variableKey
+                    userId:(NSString *)userId {
+    return [self getVariableBoolean:variableKey
+                             userId:userId
+                         attributes:nil
+                activateExperiments:NO
+                              error:nil];
 }
 
-- (BOOL)getVariableBool:(NSString *)variableKey
-                 userId:(NSString *)userId
-    activateExperiments:(bool)activateExperiments {
-    return [self getVariableBool:variableKey
-                          userId:userId
-                      attributes:nil
-             activateExperiments:activateExperiments
-                           error:nil];
+- (BOOL)getVariableBoolean:(NSString *)variableKey
+                    userId:(NSString *)userId
+       activateExperiments:(bool)activateExperiments {
+    return [self getVariableBoolean:variableKey
+                             userId:userId
+                         attributes:nil
+                activateExperiments:activateExperiments
+                              error:nil];
 }
 
-- (BOOL)getVariableBool:(NSString *)variableKey
-                 userId:(NSString *)userId
-             attributes:(nullable NSDictionary *)attributes
-    activateExperiments:(bool)activateExperiments {
-    return [self getVariableBool:variableKey
-                          userId:userId
-                      attributes:attributes
-             activateExperiments:activateExperiments
-                           error:nil];
+- (BOOL)getVariableBoolean:(NSString *)variableKey
+                    userId:(NSString *)userId
+                attributes:(nullable NSDictionary *)attributes
+       activateExperiments:(bool)activateExperiments {
+    return [self getVariableBoolean:variableKey
+                             userId:userId
+                         attributes:attributes
+                activateExperiments:activateExperiments
+                              error:nil];
 }
 
-- (BOOL)getVariableBool:(nonnull NSString *)variableKey
-                 userId:(nonnull NSString *)userId
-             attributes:(nullable NSDictionary *)attributes
-    activateExperiments:(bool)activateExperiments
-                  error:(NSError * _Nullable * _Nullable)error {
+- (BOOL)getVariableBoolean:(nonnull NSString *)variableKey
+                    userId:(nonnull NSString *)userId
+                attributes:(nullable NSDictionary *)attributes
+       activateExperiments:(bool)activateExperiments
+                     error:(NSError * _Nullable * _Nullable)error {
     BOOL variableValue = false;
     NSString *variableValueStringOrNil = [self getVariableString:variableKey
                                                           userId:userId

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
@@ -156,9 +156,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
                                       attributes:[OCMArg isNotNil]]);
     
     NSString *variableString = [optimizelyMock getVariableString:kVariableKeyForString
-                                             activateExperiments:NO
                                                           userId:kUserId
                                                       attributes:self.attributes
+                                             activateExperiments:NO
                                                            error:nil];
     
     XCTAssertEqualObjects(variableString, kVariableStringValue, "Variable string value should be \"Hello\".");
@@ -169,8 +169,8 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
 - (void)testGetVariableStringShortAPI {
     
     NSString *variableString = [self.optimizely getVariableString:kVariableKeyForString
-                                             activateExperiments:NO
-                                                          userId:kUserId];
+                                                          userId:kUserId
+                                              activateExperiments:NO];
     
     XCTAssertEqualObjects(variableString, kVariableStringDefaultValue, "Variable string value should be \"defaultStringValue\" when user doesn't pass audience conditions.");
 }
@@ -178,9 +178,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
 - (void)testGetVariableStringShortAPIWithAttributes {
     
     NSString *variableString = [self.optimizely getVariableString:kVariableKeyForString
-                                              activateExperiments:NO
                                                            userId:kUserId
-                                                       attributes:self.attributes];
+                                                       attributes:self.attributes
+                                              activateExperiments:NO];
     
     XCTAssertEqualObjects(variableString, kVariableStringValue, "Variable string value should be \"Hello\".");
 }
@@ -190,9 +190,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     id optimizelyMock = OCMPartialMock(self.optimizely);
     
     NSString *variableStringActivateExperiment = [optimizelyMock getVariableString:kVariableKeyForString
-                                                               activateExperiments:YES
                                                                             userId:kUserId
                                                                         attributes:self.attributes
+                                                               activateExperiments:YES
                                                                              error:nil];
     [self waitForExpectationsWithTimeout:2 handler:^(NSError *error) {
         if (error) {
@@ -214,9 +214,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     id optimizelyMock = OCMPartialMock(self.optimizely);
     
     NSString *variableStringActivateExperiment = [optimizelyMock getVariableString:kVariableKeyForString
-                                                               activateExperiments:YES
                                                                             userId:kUserId
                                                                         attributes:self.attributes
+                                                               activateExperiments:YES
                                                                              error:nil];
     [self waitForExpectationsWithTimeout:2 handler:^(NSError *error) {
         if (error) {
@@ -242,9 +242,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
                                       attributes:[OCMArg isNil]]);
     
     NSString *variableStringWithGroupedExperiment = [optimizelyMock getVariableString:kVariableKeyForStringGroupedExperiment
-                                                                  activateExperiments:NO
                                                                                userId:kUserId
                                                                            attributes:nil
+                                                                  activateExperiments:NO
                                                                                 error:nil];
     XCTAssertEqualObjects(variableStringWithGroupedExperiment, kVariableStringValueGroupedExperiment, "Variable string value should be \"Ciao\".");
     
@@ -261,9 +261,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     
     // Even though activateExperiments is set to YES, activate will not be called because there is no experiment associated with the variable
     NSString *variableStringNotInExperimentVariation = [self.optimizely getVariableString:kVariableKeyForStringNotInExperimentVariation
-                                                                      activateExperiments:YES
                                                                                    userId:kUserId
                                                                                attributes:nil
+                                                                      activateExperiments:YES
                                                                                     error:nil];
     
     XCTAssertEqualObjects(variableStringNotInExperimentVariation, kVariableStringNotInExperimentVariation, "Variable string value should be \"default string value\".");
@@ -280,9 +280,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
                                       attributes:[OCMArg isNotNil]]);
     
     NSString *variableString = [optimizelyMock getVariableString:kVariableKeyForString
-                                             activateExperiments:NO
                                                           userId:kUserId
                                                       attributes:nil
+                                             activateExperiments:NO
                                                            error:nil];
     
     // Should return default value
@@ -300,9 +300,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
                                       attributes:[OCMArg isNotNil]]);
     
     BOOL variableBool = [optimizelyMock getVariableBool:kVariableKeyForBool
-                                    activateExperiments:NO
                                                  userId:kUserId
                                              attributes:self.attributes
+                                    activateExperiments:NO
                                                   error:nil];
     
     XCTAssertFalse(variableBool, "Variable boolean value should be false.");
@@ -313,8 +313,8 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
 - (void)testGetVariableBoolShortAPI {
     
     BOOL variableBool = [self.optimizely getVariableBool:kVariableKeyForBool
-                                    activateExperiments:NO
-                                                 userId:kUserId];
+                                                 userId:kUserId
+                                     activateExperiments:NO];
     
     XCTAssertFalse(variableBool, "Variable boolean value should be false.");
 }
@@ -322,9 +322,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
 - (void)testGetVariableBoolShortAPIWithAttributes {
     
     BOOL variableBool = [self.optimizely getVariableBool:kVariableKeyForBool
-                                     activateExperiments:NO
                                                   userId:kUserId
-                                              attributes:self.attributes];
+                                              attributes:self.attributes
+                                     activateExperiments:NO];
     
     XCTAssertFalse(variableBool, "Variable boolean value should be false.");
 }
@@ -334,9 +334,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     id optimizelyMock = OCMPartialMock(self.optimizely);
     
     BOOL variableBoolActivateExperiment = [optimizelyMock getVariableBool:kVariableKeyForBool
-                                                      activateExperiments:YES
                                                                    userId:kUserId
                                                                attributes:self.attributes
+                                                      activateExperiments:YES
                                                                     error:nil];
     
     [self waitForExpectationsWithTimeout:2 handler:^(NSError *error) {
@@ -359,9 +359,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     id optimizelyMock = OCMPartialMock(self.optimizely);
     
     BOOL variableBoolActivateExperiment = [optimizelyMock getVariableBool:kVariableKeyForBool
-                                                      activateExperiments:YES
                                                                    userId:kUserId
                                                                attributes:self.attributes
+                                                      activateExperiments:YES
                                                                     error:nil];
     
     [self waitForExpectationsWithTimeout:2 handler:^(NSError *error) {
@@ -388,9 +388,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
                                       attributes:[OCMArg isNil]]);
     
     BOOL variableBoolWithGroupedExperiment = [optimizelyMock getVariableBool:kVariableKeyForBoolGroupedExperiment
-                                                         activateExperiments:NO
                                                                       userId:kUserId
                                                                   attributes:nil
+                                                         activateExperiments:NO
                                                                        error:nil];
     
     XCTAssertTrue(variableBoolWithGroupedExperiment);
@@ -408,9 +408,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     
     // Even though activateExperiments is set to YES, activate will not be called because there is no experiment associated with the variable
     BOOL variableBoolNotInExperimentVariation = [optimizelyMock getVariableBool:kVariableKeyForBoolNotInExperimentVariation
-                                                            activateExperiments:YES
                                                                          userId:kUserId
                                                                      attributes:nil
+                                                            activateExperiments:YES
                                                                           error:nil];
     
     XCTAssertTrue(variableBoolNotInExperimentVariation);
@@ -427,9 +427,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
                                       attributes:[OCMArg isNotNil]]);
     
     BOOL variableBool = [optimizelyMock getVariableBool:kVariableKeyForBool
-                                    activateExperiments:NO
                                                  userId:kUserId
                                              attributes:nil
+                                    activateExperiments:NO
                                                   error:nil];
     
     // Should return default value
@@ -447,9 +447,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
                                       attributes:[OCMArg isNotNil]]);
     
     NSInteger variableInt = [optimizelyMock getVariableInteger:kVariableKeyForInt
-                                           activateExperiments:NO
                                                         userId:kUserId
                                                     attributes:self.attributes
+                                           activateExperiments:NO
                                                          error:nil];
     XCTAssertEqual(variableInt, 8, "Variable integer value should be 8.");
     
@@ -459,17 +459,17 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
 - (void)testGetVariableIntegerShortAPI {
     
     int variableInt = [self.optimizely getVariableInteger:kVariableKeyForInt
-                                           activateExperiments:NO
-                                                        userId:kUserId];
+                                                   userId:kUserId
+                                      activateExperiments:NO];
     XCTAssertEqual(variableInt, 1, "Variable integer value should be 1 when user doesn't pass audience conditions.");
 }
 
 - (void)testGetVariableIntegerShortAPIWithAttributes {
     
     int variableInt = [self.optimizely getVariableInteger:kVariableKeyForInt
-                                      activateExperiments:NO
                                                    userId:kUserId
-                                               attributes:self.attributes];
+                                               attributes:self.attributes
+                                      activateExperiments:NO];
     XCTAssertEqual(variableInt, 8, "Variable integer value should be 8.");
 }
 
@@ -478,9 +478,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     id optimizelyMock = OCMPartialMock(self.optimizely);
     
     NSInteger variableIntActivateExperiment = [self.optimizely getVariableInteger:kVariableKeyForInt
-                                                              activateExperiments:YES
                                                                            userId:kUserId
                                                                        attributes:self.attributes
+                                                              activateExperiments:YES
                                                                             error:nil];
     [self waitForExpectationsWithTimeout:2 handler:^(NSError *error) {
         if (error) {
@@ -502,9 +502,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     id optimizelyMock = OCMPartialMock(self.optimizely);
     
     NSInteger variableIntActivateExperiment = [self.optimizely getVariableInteger:kVariableKeyForInt
-                                                              activateExperiments:YES
                                                                            userId:kUserId
                                                                        attributes:self.attributes
+                                                              activateExperiments:YES
                                                                             error:nil];
     [self waitForExpectationsWithTimeout:2 handler:^(NSError *error) {
         if (error) {
@@ -530,9 +530,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
                                       attributes:[OCMArg isNil]]);
     
     NSInteger variableIntWithGroupedExperiment = [self.optimizely getVariableInteger:kVariableKeyForIntegerGroupedExperiment
-                                                                 activateExperiments:NO
                                                                               userId:kUserId
                                                                           attributes:nil
+                                                                 activateExperiments:NO
                                                                                error:nil];
     XCTAssertEqual(variableIntWithGroupedExperiment, 90, "Variable integer value should be 90.");
     
@@ -549,9 +549,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     
     // Even though activateExperiments is set to YES, activate will not be called because there is no experiment associated with the variable
     NSInteger variableIntNotInExperimentVariation = [self.optimizely getVariableInteger:kVariableKeyForIntegerNotInExperimentVariation
-                                                                    activateExperiments:YES
                                                                                  userId:kUserId
                                                                              attributes:nil
+                                                                    activateExperiments:YES
                                                                                   error:nil];
     XCTAssertEqual(variableIntNotInExperimentVariation, 101010101, "Variable integer value should be 101010101.");
     
@@ -567,9 +567,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
                                       attributes:[OCMArg isNotNil]]);
     
     NSInteger variableInt = [optimizelyMock getVariableInteger:kVariableKeyForInt
-                                           activateExperiments:NO
                                                         userId:kUserId
                                                     attributes:nil
+                                           activateExperiments:NO
                                                          error:nil];
     // Should return default value
     XCTAssertEqual(variableInt, 1, "Variable integer value should be 1.");
@@ -586,9 +586,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
                                       attributes:[OCMArg isNotNil]]);
     
     double variableFloat = [self.optimizely getVariableFloat:kVariableKeyForFloat
-                                         activateExperiments:NO
                                                       userId:kUserId
                                                   attributes:self.attributes
+                                         activateExperiments:NO
                                                        error:nil];
     XCTAssertEqualWithAccuracy(variableFloat, 1.8, 0.0000001);
     
@@ -597,16 +597,16 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
 
 - (void)testGetVariableFloatShortAPI {
     double variableFloat = [self.optimizely getVariableFloat:kVariableKeyForFloat
-                                         activateExperiments:NO
-                                                      userId:kUserId];
+                                                      userId:kUserId
+                                         activateExperiments:NO];
     XCTAssertEqualWithAccuracy(variableFloat, .5, 0.0000001, @"float value should be 0.5 when user doesn't pass audience conditions");
 }
 
 - (void)testGetVariableFloatShortAPIWithAttributes {
     double variableFloat = [self.optimizely getVariableFloat:kVariableKeyForFloat
-                                         activateExperiments:NO
                                                       userId:kUserId
-                                                  attributes:self.attributes];
+                                                  attributes:self.attributes
+                                         activateExperiments:NO];
     XCTAssertEqualWithAccuracy(variableFloat, 1.8, 0.0000001);
 }
 
@@ -615,9 +615,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     id optimizelyMock = OCMPartialMock(self.optimizely);
     
     double variableFloatActivateExperiment = [self.optimizely getVariableFloat:kVariableKeyForFloat
-                                                           activateExperiments:YES
                                                                         userId:kUserId
                                                                     attributes:self.attributes
+                                                           activateExperiments:YES
                                                                          error:nil];
     [self waitForExpectationsWithTimeout:2 handler:^(NSError *error) {
         if (error) {
@@ -639,9 +639,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     id optimizelyMock = OCMPartialMock(self.optimizely);
     
     double variableFloatActivateExperiment = [self.optimizely getVariableFloat:kVariableKeyForFloat
-                                                           activateExperiments:YES
                                                                         userId:kUserId
                                                                     attributes:self.attributes
+                                                           activateExperiments:YES
                                                                          error:nil];
     [self waitForExpectationsWithTimeout:2 handler:^(NSError *error) {
         if (error) {
@@ -667,9 +667,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
                                       attributes:[OCMArg isNil]]);
     
     double variableFloatWithGroupedExperiment = [self.optimizely getVariableFloat:kVariableKeyForFloatGroupedExperiment
-                                                              activateExperiments:NO
                                                                            userId:kUserId
                                                                        attributes:nil
+                                                              activateExperiments:NO
                                                                             error:nil];
     
     XCTAssertEqualWithAccuracy(variableFloatWithGroupedExperiment, 75.5, 0.0000001, "Variable float value should be 75.5.");
@@ -687,9 +687,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     
     // Even though activateExperiments is set to YES, activate will not be called because there is no experiment associated with the variable
     double variableFloatNotInExperimentVariation = [self.optimizely getVariableFloat:kVariableKeyForFloatNotInExperimentVariation
-                                                                 activateExperiments:YES
                                                                               userId:kUserId
                                                                           attributes:nil
+                                                                 activateExperiments:YES
                                                                                error:nil];
     
     XCTAssertEqualWithAccuracy(variableFloatNotInExperimentVariation, 10101.101, 0.0000001, "Variable float value should be 10101.101.");
@@ -706,9 +706,9 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
                                       attributes:[OCMArg isNotNil]]);
     
     double variableFloat = [self.optimizely getVariableFloat:kVariableKeyForFloat
-                                         activateExperiments:NO
                                                       userId:kUserId
                                                   attributes:nil
+                                         activateExperiments:NO
                                                        error:nil];
     // Should return default value
     XCTAssertEqualWithAccuracy(variableFloat, 0.5, 0.0000001);

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
@@ -175,7 +175,7 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
 
 - (void)testGetVariableStringShortAPIWithActivateExperiments {
     NSString *variableString = [self.optimizely getVariableString:kVariableKeyForString
-                                                          userId:kUserId
+                                                           userId:kUserId
                                               activateExperiments:NO];
     
     XCTAssertEqualObjects(variableString, kVariableStringDefaultValue, "Variable string value should be \"defaultStringValue\" when user doesn't pass audience conditions.");
@@ -297,7 +297,7 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     [optimizelyMock stopMocking];
 }
 
-- (void)testGetVariableBool {
+- (void)testgetVariableBoolean {
     id optimizelyMock = OCMPartialMock(self.optimizely);
     
     // Ensure activateExperiment is not called
@@ -305,7 +305,7 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
                                           userId:[OCMArg isNotNil]
                                       attributes:[OCMArg isNotNil]]);
     
-    BOOL variableBool = [optimizelyMock getVariableBool:kVariableKeyForBool
+    BOOL variableBool = [optimizelyMock getVariableBoolean:kVariableKeyForBool
                                                  userId:kUserId
                                              attributes:self.attributes
                                     activateExperiments:NO
@@ -316,23 +316,23 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     [optimizelyMock stopMocking];
 }
 
-- (void)testGetVariableBoolShortAPI {
-    BOOL variableBool = [self.optimizely getVariableBool:kVariableKeyForBool
+- (void)testgetVariableBooleanShortAPI {
+    BOOL variableBool = [self.optimizely getVariableBoolean:kVariableKeyForBool
                                                   userId:kUserId];
     
     XCTAssertFalse(variableBool, "Variable boolean value should be false.");
 }
 
-- (void)testGetVariableBoolShortAPIWithActivateExperiments {
-    BOOL variableBool = [self.optimizely getVariableBool:kVariableKeyForBool
-                                                 userId:kUserId
+- (void)testgetVariableBooleanShortAPIWithActivateExperiments {
+    BOOL variableBool = [self.optimizely getVariableBoolean:kVariableKeyForBool
+                                                  userId:kUserId
                                      activateExperiments:NO];
     
     XCTAssertFalse(variableBool, "Variable boolean value should be false.");
 }
 
-- (void)testGetVariableBoolShortAPIWithAttributes {
-    BOOL variableBool = [self.optimizely getVariableBool:kVariableKeyForBool
+- (void)testgetVariableBooleanShortAPIWithAttributes {
+    BOOL variableBool = [self.optimizely getVariableBoolean:kVariableKeyForBool
                                                   userId:kUserId
                                               attributes:self.attributes
                                      activateExperiments:NO];
@@ -340,11 +340,11 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     XCTAssertFalse(variableBool, "Variable boolean value should be false.");
 }
 
-- (void)testGetVariableBoolWithActivateExperimentsTrue {
+- (void)testgetVariableBooleanWithActivateExperimentsTrue {
     [self stubSuccessResponseForEventRequest];
     id optimizelyMock = OCMPartialMock(self.optimizely);
     
-    BOOL variableBoolActivateExperiment = [optimizelyMock getVariableBool:kVariableKeyForBool
+    BOOL variableBoolActivateExperiment = [optimizelyMock getVariableBoolean:kVariableKeyForBool
                                                                    userId:kUserId
                                                                attributes:self.attributes
                                                       activateExperiments:YES
@@ -352,7 +352,7 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     
     [self waitForExpectationsWithTimeout:2 handler:^(NSError *error) {
         if (error) {
-            NSLog(@"Timeout error for testGetVariableBoolWithActivateExperimentsTrue: %@", error);
+            NSLog(@"Timeout error for testgetVariableBooleanWithActivateExperimentsTrue: %@", error);
         }
     }];
     
@@ -365,11 +365,11 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     [optimizelyMock stopMocking];
 }
 
-- (void)testGetVariableBoolWithActivateExperimentsTrueAndFailureResponseForEventRequest {
+- (void)testgetVariableBooleanWithActivateExperimentsTrueAndFailureResponseForEventRequest {
     [self stubFailureResponseForEventRequest];
     id optimizelyMock = OCMPartialMock(self.optimizely);
     
-    BOOL variableBoolActivateExperiment = [optimizelyMock getVariableBool:kVariableKeyForBool
+    BOOL variableBoolActivateExperiment = [optimizelyMock getVariableBoolean:kVariableKeyForBool
                                                                    userId:kUserId
                                                                attributes:self.attributes
                                                       activateExperiments:YES
@@ -377,7 +377,7 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     
     [self waitForExpectationsWithTimeout:2 handler:^(NSError *error) {
         if (error) {
-            NSLog(@"Timeout error for testGetVariableBoolWithActivateExperimentsTrue: %@", error);
+            NSLog(@"Timeout error for testgetVariableBooleanWithActivateExperimentsTrue: %@", error);
         }
     }];
     
@@ -390,7 +390,7 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     [optimizelyMock stopMocking];
 }
 
-- (void)testGetVariableBoolWithGroupedExperiment {
+- (void)testgetVariableBooleanWithGroupedExperiment {
     id optimizelyMock = OCMPartialMock(self.optimizely);
     
     // Ensure activateExperiment is not called
@@ -398,7 +398,7 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
                                           userId:[OCMArg isNotNil]
                                       attributes:[OCMArg isNil]]);
     
-    BOOL variableBoolWithGroupedExperiment = [optimizelyMock getVariableBool:kVariableKeyForBoolGroupedExperiment
+    BOOL variableBoolWithGroupedExperiment = [optimizelyMock getVariableBoolean:kVariableKeyForBoolGroupedExperiment
                                                                       userId:kUserId
                                                                   attributes:nil
                                                          activateExperiments:NO
@@ -409,7 +409,7 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     [optimizelyMock stopMocking];
 }
 
-- (void)testGetVariableBoolVariableNotInAnyExperiments {
+- (void)testgetVariableBooleanVariableNotInAnyExperiments {
     id optimizelyMock = OCMPartialMock(self.optimizely);
     
     // Ensure activateExperiment is not called
@@ -418,7 +418,7 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
                                       attributes:[OCMArg isNil]]);
     
     // Even though activateExperiments is set to YES, activate will not be called because there is no experiment associated with the variable
-    BOOL variableBoolNotInExperimentVariation = [optimizelyMock getVariableBool:kVariableKeyForBoolNotInExperimentVariation
+    BOOL variableBoolNotInExperimentVariation = [optimizelyMock getVariableBoolean:kVariableKeyForBoolNotInExperimentVariation
                                                                          userId:kUserId
                                                                      attributes:nil
                                                             activateExperiments:YES
@@ -429,7 +429,7 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
     [optimizelyMock stopMocking];
 }
 
-- (void)testGetVariableBoolUserNotBucketedIntoExperiment {
+- (void)testgetVariableBooleanUserNotBucketedIntoExperiment {
     id optimizelyMock = OCMPartialMock(self.optimizely);
     
     // Ensure activateExperiment is not called
@@ -437,7 +437,7 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
                                           userId:[OCMArg isNotNil]
                                       attributes:[OCMArg isNotNil]]);
     
-    BOOL variableBool = [optimizelyMock getVariableBool:kVariableKeyForBool
+    BOOL variableBool = [optimizelyMock getVariableBoolean:kVariableKeyForBool
                                                  userId:kUserId
                                              attributes:nil
                                     activateExperiments:NO

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
@@ -167,7 +167,13 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
 }
 
 - (void)testGetVariableStringShortAPI {
+    NSString *variableString = [self.optimizely getVariableString:kVariableKeyForString
+                                                           userId:kUserId];
     
+    XCTAssertEqualObjects(variableString, kVariableStringDefaultValue, "Variable string value should be \"defaultStringValue\" when user doesn't pass audience conditions.");
+}
+
+- (void)testGetVariableStringShortAPIWithActivateExperiments {
     NSString *variableString = [self.optimizely getVariableString:kVariableKeyForString
                                                           userId:kUserId
                                               activateExperiments:NO];
@@ -311,7 +317,13 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
 }
 
 - (void)testGetVariableBoolShortAPI {
+    BOOL variableBool = [self.optimizely getVariableBool:kVariableKeyForBool
+                                                  userId:kUserId];
     
+    XCTAssertFalse(variableBool, "Variable boolean value should be false.");
+}
+
+- (void)testGetVariableBoolShortAPIWithActivateExperiments {
     BOOL variableBool = [self.optimizely getVariableBool:kVariableKeyForBool
                                                  userId:kUserId
                                      activateExperiments:NO];
@@ -320,7 +332,6 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
 }
 
 - (void)testGetVariableBoolShortAPIWithAttributes {
-    
     BOOL variableBool = [self.optimizely getVariableBool:kVariableKeyForBool
                                                   userId:kUserId
                                               attributes:self.attributes
@@ -457,7 +468,12 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
 }
 
 - (void)testGetVariableIntegerShortAPI {
-    
+    int variableInt = [self.optimizely getVariableInteger:kVariableKeyForInt
+                                                   userId:kUserId];
+    XCTAssertEqual(variableInt, 1, "Variable integer value should be 1 when user doesn't pass audience conditions.");
+}
+
+- (void)testGetVariableIntegerShortAPIWithActivateExperiments {
     int variableInt = [self.optimizely getVariableInteger:kVariableKeyForInt
                                                    userId:kUserId
                                       activateExperiments:NO];
@@ -596,6 +612,12 @@ static NSString *const kVariableStringNotInExperimentVariation = @"default strin
 }
 
 - (void)testGetVariableFloatShortAPI {
+    double variableFloat = [self.optimizely getVariableFloat:kVariableKeyForFloat
+                                                      userId:kUserId];
+    XCTAssertEqualWithAccuracy(variableFloat, .5, 0.0000001, @"float value should be 0.5 when user doesn't pass audience conditions");
+}
+
+- (void)testGetVariableFloatShortAPIWithActivateExperiments {
     double variableFloat = [self.optimizely getVariableFloat:kVariableKeyForFloat
                                                       userId:kUserId
                                          activateExperiments:NO];

--- a/OptimizelySDKShared/OptimizelySDKShared/OPTLYClient.m
+++ b/OptimizelySDKShared/OptimizelySDKShared/OPTLYClient.m
@@ -143,6 +143,7 @@ NSString *const OPTLYClientDummyOptimizelyWarning = @"Optimizely is not initiali
     }
     return [self.optimizely getVariableString:variableKey
                                        userId:userId];
+}
 
 - (nullable NSString *)getVariableString:(nonnull NSString *)variableKey
                                   userId:(nonnull NSString *)userId

--- a/OptimizelySDKShared/OptimizelySDKShared/OPTLYClient.m
+++ b/OptimizelySDKShared/OptimizelySDKShared/OPTLYClient.m
@@ -195,8 +195,8 @@ NSString *const OPTLYClientDummyOptimizelyWarning = @"Optimizely is not initiali
                                         error:error];
 }
 
-- (BOOL)getVariableBool:(nonnull NSString *)variableKey
-                 userId:(nonnull NSString *)userId {
+- (BOOL)getVariableBoolean:(nonnull NSString *)variableKey
+                    userId:(nonnull NSString *)userId {
     if (self.optimizely == nil) {
         [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
                                  OPTLYClientDummyOptimizelyWarning,
@@ -204,12 +204,28 @@ NSString *const OPTLYClientDummyOptimizelyWarning = @"Optimizely is not initiali
                       withLevel:OptimizelyLogLevelWarning];
         return false;
     }
-    return [self.optimizely getVariableBool:variableKey
-                                     userId:userId];
+    return [self.optimizely getVariableBoolean:variableKey
+                                        userId:userId];
 }
     
-- (BOOL)getVariableBool:(nonnull NSString *)variableKey
-                 userId:(nonnull NSString *)userId
+- (BOOL)getVariableBoolean:(nonnull NSString *)variableKey
+                    userId:(nonnull NSString *)userId
+       activateExperiments:(bool)activateExperiments {
+    if (self.optimizely == nil) {
+        [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
+                                 OPTLYClientDummyOptimizelyWarning,
+                                 [NSString stringWithFormat:OPTLYLoggerMessagesVariableUnknownForVariableKey, variableKey]]
+                      withLevel:OptimizelyLogLevelWarning];
+        return false;
+    }
+    return [self.optimizely getVariableBoolean:variableKey
+                                        userId:userId
+                           activateExperiments:activateExperiments];
+}
+
+- (BOOL)getVariableBoolean:(nonnull NSString *)variableKey
+                    userId:(nonnull NSString *)userId
+                attributes:(nullable NSDictionary *)attributes
     activateExperiments:(bool)activateExperiments {
     if (self.optimizely == nil) {
         [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
@@ -218,15 +234,17 @@ NSString *const OPTLYClientDummyOptimizelyWarning = @"Optimizely is not initiali
                       withLevel:OptimizelyLogLevelWarning];
         return false;
     }
-    return [self.optimizely getVariableBool:variableKey
-                                     userId:userId
-                        activateExperiments:activateExperiments];
+    return [self.optimizely getVariableBoolean:variableKey
+                                        userId:userId
+                                    attributes:attributes
+                           activateExperiments:activateExperiments];
 }
 
-- (BOOL)getVariableBool:(nonnull NSString *)variableKey
-                 userId:(nonnull NSString *)userId
-             attributes:(nullable NSDictionary *)attributes
-    activateExperiments:(bool)activateExperiments {
+- (BOOL)getVariableBoolean:(nonnull NSString *)variableKey
+                    userId:(nonnull NSString *)userId
+                attributes:(nullable NSDictionary *)attributes
+       activateExperiments:(bool)activateExperiments
+                     error:(NSError * _Nullable * _Nullable)error {
     if (self.optimizely == nil) {
         [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
                                  OPTLYClientDummyOptimizelyWarning,
@@ -234,29 +252,11 @@ NSString *const OPTLYClientDummyOptimizelyWarning = @"Optimizely is not initiali
                       withLevel:OptimizelyLogLevelWarning];
         return false;
     }
-    return [self.optimizely getVariableBool:variableKey
-                                     userId:userId
-                                 attributes:attributes
-                        activateExperiments:activateExperiments];
-}
-
-- (BOOL)getVariableBool:(nonnull NSString *)variableKey
-                 userId:(nonnull NSString *)userId
-             attributes:(nullable NSDictionary *)attributes
-    activateExperiments:(bool)activateExperiments
-                  error:(NSError * _Nullable * _Nullable)error {
-    if (self.optimizely == nil) {
-        [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
-                                 OPTLYClientDummyOptimizelyWarning,
-                                 [NSString stringWithFormat:OPTLYLoggerMessagesVariableUnknownForVariableKey, variableKey]]
-                      withLevel:OptimizelyLogLevelWarning];
-        return false;
-    }
-    return [self.optimizely getVariableBool:variableKey
-                                     userId:userId
-                                 attributes:attributes
-                        activateExperiments:activateExperiments
-                                      error:error];
+    return [self.optimizely getVariableBoolean:variableKey
+                                        userId:userId
+                                    attributes:attributes
+                           activateExperiments:activateExperiments
+                                         error:error];
 }
 
 - (int)getVariableInteger:(nonnull NSString *)variableKey

--- a/OptimizelySDKShared/OptimizelySDKShared/OPTLYClient.m
+++ b/OptimizelySDKShared/OptimizelySDKShared/OPTLYClient.m
@@ -133,24 +133,8 @@ NSString *const OPTLYClientDummyOptimizelyWarning = @"Optimizely is not initiali
 #pragma mark - Live variable getters
 
 - (nullable NSString *)getVariableString:(nonnull NSString *)variableKey
-                     activateExperiments:(bool)activateExperiments
-                                  userId:(nonnull NSString *)userId {
-    if (self.optimizely == nil) {
-        [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
-                                 OPTLYClientDummyOptimizelyWarning,
-                                 [NSString stringWithFormat:OPTLYLoggerMessagesVariableUnknownForVariableKey, variableKey]]
-                      withLevel:OptimizelyLogLevelWarning];
-        return nil;
-    }
-    return [self.optimizely getVariableString:variableKey
-                          activateExperiments:activateExperiments
-                                       userId:userId];
-}
-
-- (nullable NSString *)getVariableString:(nonnull NSString *)variableKey
-                     activateExperiments:(bool)activateExperiments
                                   userId:(nonnull NSString *)userId
-                              attributes:(nullable NSDictionary *)attributes {
+                     activateExperiments:(bool)activateExperiments {
     if (self.optimizely == nil) {
         [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
                                  OPTLYClientDummyOptimizelyWarning,
@@ -159,15 +143,31 @@ NSString *const OPTLYClientDummyOptimizelyWarning = @"Optimizely is not initiali
         return nil;
     }
     return [self.optimizely getVariableString:variableKey
-                          activateExperiments:activateExperiments
                                        userId:userId
-                                   attributes:attributes];
+                          activateExperiments:activateExperiments];
 }
 
 - (nullable NSString *)getVariableString:(nonnull NSString *)variableKey
-                     activateExperiments:(bool)activateExperiments
                                   userId:(nonnull NSString *)userId
                               attributes:(nullable NSDictionary *)attributes
+                     activateExperiments:(bool)activateExperiments {
+    if (self.optimizely == nil) {
+        [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
+                                 OPTLYClientDummyOptimizelyWarning,
+                                 [NSString stringWithFormat:OPTLYLoggerMessagesVariableUnknownForVariableKey, variableKey]]
+                      withLevel:OptimizelyLogLevelWarning];
+        return nil;
+    }
+    return [self.optimizely getVariableString:variableKey
+                                       userId:userId
+                                   attributes:attributes
+                          activateExperiments:activateExperiments];
+}
+
+- (nullable NSString *)getVariableString:(nonnull NSString *)variableKey
+                                  userId:(nonnull NSString *)userId
+                              attributes:(nullable NSDictionary *)attributes
+                     activateExperiments:(bool)activateExperiments
                                    error:(NSError * _Nullable * _Nullable)error {
     if (self.optimizely == nil) {
         [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
@@ -177,31 +177,15 @@ NSString *const OPTLYClientDummyOptimizelyWarning = @"Optimizely is not initiali
         return nil;
     }
     return [self.optimizely getVariableString:variableKey
-                          activateExperiments:activateExperiments
                                        userId:userId
                                    attributes:attributes
+                          activateExperiments:activateExperiments
                                         error:error];
 }
 
 - (BOOL)getVariableBool:(nonnull NSString *)variableKey
-    activateExperiments:(bool)activateExperiments
-                 userId:(nonnull NSString *)userId {
-    if (self.optimizely == nil) {
-        [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
-                                 OPTLYClientDummyOptimizelyWarning,
-                                 [NSString stringWithFormat:OPTLYLoggerMessagesVariableUnknownForVariableKey, variableKey]]
-                      withLevel:OptimizelyLogLevelWarning];
-        return false;
-    }
-    return [self.optimizely getVariableBool:variableKey
-                        activateExperiments:activateExperiments
-                                     userId:userId];
-}
-
-- (BOOL)getVariableBool:(nonnull NSString *)variableKey
-    activateExperiments:(bool)activateExperiments
                  userId:(nonnull NSString *)userId
-             attributes:(nullable NSDictionary *)attributes {
+    activateExperiments:(bool)activateExperiments {
     if (self.optimizely == nil) {
         [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
                                  OPTLYClientDummyOptimizelyWarning,
@@ -210,15 +194,31 @@ NSString *const OPTLYClientDummyOptimizelyWarning = @"Optimizely is not initiali
         return false;
     }
     return [self.optimizely getVariableBool:variableKey
-                        activateExperiments:activateExperiments
                                      userId:userId
-                                 attributes:attributes];
+                        activateExperiments:activateExperiments];
 }
 
 - (BOOL)getVariableBool:(nonnull NSString *)variableKey
-    activateExperiments:(bool)activateExperiments
                  userId:(nonnull NSString *)userId
              attributes:(nullable NSDictionary *)attributes
+    activateExperiments:(bool)activateExperiments {
+    if (self.optimizely == nil) {
+        [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
+                                 OPTLYClientDummyOptimizelyWarning,
+                                 [NSString stringWithFormat:OPTLYLoggerMessagesVariableUnknownForVariableKey, variableKey]]
+                      withLevel:OptimizelyLogLevelWarning];
+        return false;
+    }
+    return [self.optimizely getVariableBool:variableKey
+                                     userId:userId
+                                 attributes:attributes
+                        activateExperiments:activateExperiments];
+}
+
+- (BOOL)getVariableBool:(nonnull NSString *)variableKey
+                 userId:(nonnull NSString *)userId
+             attributes:(nullable NSDictionary *)attributes
+    activateExperiments:(bool)activateExperiments
                   error:(NSError * _Nullable * _Nullable)error {
     if (self.optimizely == nil) {
         [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
@@ -228,31 +228,15 @@ NSString *const OPTLYClientDummyOptimizelyWarning = @"Optimizely is not initiali
         return false;
     }
     return [self.optimizely getVariableBool:variableKey
-                        activateExperiments:activateExperiments
                                      userId:userId
                                  attributes:attributes
+                        activateExperiments:activateExperiments
                                       error:error];
 }
 
 - (int)getVariableInteger:(nonnull NSString *)variableKey
-      activateExperiments:(bool)activateExperiments
-                   userId:(nonnull NSString *)userId {
-    if (self.optimizely == nil) {
-        [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
-                                 OPTLYClientDummyOptimizelyWarning,
-                                 [NSString stringWithFormat:OPTLYLoggerMessagesVariableUnknownForVariableKey, variableKey]]
-                      withLevel:OptimizelyLogLevelWarning];
-        return 0;
-    }
-    return [self.optimizely getVariableInteger:variableKey
-                           activateExperiments:activateExperiments
-                                        userId:userId];
-}
-
-- (int)getVariableInteger:(nonnull NSString *)variableKey
-      activateExperiments:(bool)activateExperiments
                    userId:(nonnull NSString *)userId
-               attributes:(nullable NSDictionary *)attributes {
+      activateExperiments:(bool)activateExperiments {
     if (self.optimizely == nil) {
         [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
                                  OPTLYClientDummyOptimizelyWarning,
@@ -261,15 +245,31 @@ NSString *const OPTLYClientDummyOptimizelyWarning = @"Optimizely is not initiali
         return 0;
     }
     return [self.optimizely getVariableInteger:variableKey
-                           activateExperiments:activateExperiments
                                         userId:userId
-                                    attributes:attributes];
+                           activateExperiments:activateExperiments];
 }
 
 - (int)getVariableInteger:(nonnull NSString *)variableKey
-      activateExperiments:(bool)activateExperiments
+                   userId:(nonnull NSString *)userId
+               attributes:(nullable NSDictionary *)attributes
+      activateExperiments:(bool)activateExperiments {
+    if (self.optimizely == nil) {
+        [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
+                                 OPTLYClientDummyOptimizelyWarning,
+                                 [NSString stringWithFormat:OPTLYLoggerMessagesVariableUnknownForVariableKey, variableKey]]
+                      withLevel:OptimizelyLogLevelWarning];
+        return 0;
+    }
+    return [self.optimizely getVariableInteger:variableKey
+                                        userId:userId
+                                    attributes:attributes
+                           activateExperiments:activateExperiments];
+}
+
+- (int)getVariableInteger:(nonnull NSString *)variableKey
                     userId:(nonnull NSString *)userId
                attributes:(nullable NSDictionary *)attributes
+      activateExperiments:(bool)activateExperiments
                     error:(NSError * _Nullable * _Nullable)error {
     if (self.optimizely == nil) {
         [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
@@ -279,31 +279,15 @@ NSString *const OPTLYClientDummyOptimizelyWarning = @"Optimizely is not initiali
         return 0;
     }
     return [self.optimizely getVariableInteger:variableKey
-                           activateExperiments:activateExperiments
                                         userId:userId
                                     attributes:attributes
+                           activateExperiments:activateExperiments
                                          error:error];
 }
 
 - (double)getVariableFloat:(nonnull NSString *)variableKey
-       activateExperiments:(bool)activateExperiments
-                    userId:(nonnull NSString *)userId {
-    if (self.optimizely == nil) {
-        [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
-                                 OPTLYClientDummyOptimizelyWarning,
-                                 [NSString stringWithFormat:OPTLYLoggerMessagesVariableUnknownForVariableKey, variableKey]]
-                      withLevel:OptimizelyLogLevelWarning];
-        return 0;
-    }
-    return [self.optimizely getVariableFloat:variableKey
-                         activateExperiments:activateExperiments
-                                      userId:userId];
-}
-
-- (double)getVariableFloat:(nonnull NSString *)variableKey
-       activateExperiments:(bool)activateExperiments
                     userId:(nonnull NSString *)userId
-                attributes:(nullable NSDictionary *)attributes{
+       activateExperiments:(bool)activateExperiments {
     if (self.optimizely == nil) {
         [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
                                  OPTLYClientDummyOptimizelyWarning,
@@ -312,15 +296,31 @@ NSString *const OPTLYClientDummyOptimizelyWarning = @"Optimizely is not initiali
         return 0;
     }
     return [self.optimizely getVariableFloat:variableKey
-                         activateExperiments:activateExperiments
                                       userId:userId
-                                  attributes:attributes];
+                         activateExperiments:activateExperiments];
 }
 
 - (double)getVariableFloat:(nonnull NSString *)variableKey
-       activateExperiments:(bool)activateExperiments
                     userId:(nonnull NSString *)userId
                 attributes:(nullable NSDictionary *)attributes
+       activateExperiments:(bool)activateExperiments {
+    if (self.optimizely == nil) {
+        [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
+                                 OPTLYClientDummyOptimizelyWarning,
+                                 [NSString stringWithFormat:OPTLYLoggerMessagesVariableUnknownForVariableKey, variableKey]]
+                      withLevel:OptimizelyLogLevelWarning];
+        return 0;
+    }
+    return [self.optimizely getVariableFloat:variableKey
+                                      userId:userId
+                                  attributes:attributes
+                         activateExperiments:activateExperiments];
+}
+
+- (double)getVariableFloat:(nonnull NSString *)variableKey
+                    userId:(nonnull NSString *)userId
+                attributes:(nullable NSDictionary *)attributes
+       activateExperiments:(bool)activateExperiments
                      error:(NSError * _Nullable * _Nullable)error {
     if (self.optimizely == nil) {
         [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
@@ -330,9 +330,9 @@ NSString *const OPTLYClientDummyOptimizelyWarning = @"Optimizely is not initiali
         return 0;
     }
     return [self.optimizely getVariableFloat:variableKey
-                         activateExperiments:activateExperiments
                                       userId:userId
                                   attributes:attributes
+                         activateExperiments:activateExperiments
                                        error:error];
 }
 

--- a/OptimizelySDKShared/OptimizelySDKShared/OPTLYClient.m
+++ b/OptimizelySDKShared/OptimizelySDKShared/OPTLYClient.m
@@ -133,6 +133,18 @@ NSString *const OPTLYClientDummyOptimizelyWarning = @"Optimizely is not initiali
 #pragma mark - Live variable getters
 
 - (nullable NSString *)getVariableString:(nonnull NSString *)variableKey
+                                  userId:(nonnull NSString *)userId {
+    if (self.optimizely == nil) {
+        [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
+                                 OPTLYClientDummyOptimizelyWarning,
+                                 [NSString stringWithFormat:OPTLYLoggerMessagesVariableUnknownForVariableKey, variableKey]]
+                      withLevel:OptimizelyLogLevelWarning];
+        return nil;
+    }
+    return [self.optimizely getVariableString:variableKey
+                                       userId:userId];
+
+- (nullable NSString *)getVariableString:(nonnull NSString *)variableKey
                                   userId:(nonnull NSString *)userId
                      activateExperiments:(bool)activateExperiments {
     if (self.optimizely == nil) {
@@ -183,6 +195,19 @@ NSString *const OPTLYClientDummyOptimizelyWarning = @"Optimizely is not initiali
                                         error:error];
 }
 
+- (BOOL)getVariableBool:(nonnull NSString *)variableKey
+                 userId:(nonnull NSString *)userId {
+    if (self.optimizely == nil) {
+        [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
+                                 OPTLYClientDummyOptimizelyWarning,
+                                 [NSString stringWithFormat:OPTLYLoggerMessagesVariableUnknownForVariableKey, variableKey]]
+                      withLevel:OptimizelyLogLevelWarning];
+        return false;
+    }
+    return [self.optimizely getVariableBool:variableKey
+                                     userId:userId];
+}
+    
 - (BOOL)getVariableBool:(nonnull NSString *)variableKey
                  userId:(nonnull NSString *)userId
     activateExperiments:(bool)activateExperiments {
@@ -235,6 +260,19 @@ NSString *const OPTLYClientDummyOptimizelyWarning = @"Optimizely is not initiali
 }
 
 - (int)getVariableInteger:(nonnull NSString *)variableKey
+                   userId:(nonnull NSString *)userId {
+    if (self.optimizely == nil) {
+        [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
+                                 OPTLYClientDummyOptimizelyWarning,
+                                 [NSString stringWithFormat:OPTLYLoggerMessagesVariableUnknownForVariableKey, variableKey]]
+                      withLevel:OptimizelyLogLevelWarning];
+        return 0;
+    }
+    return [self.optimizely getVariableInteger:variableKey
+                                        userId:userId];
+}
+    
+- (int)getVariableInteger:(nonnull NSString *)variableKey
                    userId:(nonnull NSString *)userId
       activateExperiments:(bool)activateExperiments {
     if (self.optimizely == nil) {
@@ -285,6 +323,19 @@ NSString *const OPTLYClientDummyOptimizelyWarning = @"Optimizely is not initiali
                                          error:error];
 }
 
+- (double)getVariableFloat:(nonnull NSString *)variableKey
+                    userId:(nonnull NSString *)userId {
+    if (self.optimizely == nil) {
+        [self.logger logMessage:[NSString stringWithFormat:@"%@ %@",
+                                 OPTLYClientDummyOptimizelyWarning,
+                                 [NSString stringWithFormat:OPTLYLoggerMessagesVariableUnknownForVariableKey, variableKey]]
+                      withLevel:OptimizelyLogLevelWarning];
+        return 0;
+    }
+    return [self.optimizely getVariableFloat:variableKey
+                                      userId:userId];
+}
+    
 - (double)getVariableFloat:(nonnull NSString *)variableKey
                     userId:(nonnull NSString *)userId
        activateExperiments:(bool)activateExperiments {


### PR DESCRIPTION
This change:

1) moves activateExperiments to be the last parameter (second to last in the case where an optional error parameter can be passed in, so that the ordering can match the Android SDK)
2) adds getter signatures where activateExperiments is not included (eg, only need to pass in variableKey and userId)
3) change getVariableBool to getVariableBoolean