### PR TITLE
Add 'out' and 'NS_SWIFT_NOTHROW' to 4 variableXxx:...:error: declarations

### DIFF
--- a/OptimizelySDKCore/OptimizelySDKCore/Optimizely.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/Optimizely.h
@@ -226,7 +226,7 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
                                userId:(nonnull NSString *)userId
                            attributes:(nullable NSDictionary *)attributes
                    activateExperiment:(BOOL)activateExperiment
-                                error:(NSError * _Nullable * _Nullable)error;
+                                error:(out NSError * _Nullable * _Nullable)error NS_SWIFT_NOTHROW;
 
 /**
  * Gets the boolean value of the live variable.
@@ -294,7 +294,7 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
                  userId:(nonnull NSString *)userId
              attributes:(nullable NSDictionary *)attributes
      activateExperiment:(BOOL)activateExperiment
-                  error:(NSError * _Nullable * _Nullable)error;
+                  error:(out NSError * _Nullable * _Nullable)error NS_SWIFT_NOTHROW;
 
 
 /**
@@ -363,7 +363,7 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
                       userId:(nonnull NSString *)userId
                   attributes:(nullable NSDictionary *)attributes
           activateExperiment:(BOOL)activateExperiment
-                       error:(NSError * _Nullable * _Nullable)error;
+                       error:(out NSError * _Nullable * _Nullable)error NS_SWIFT_NOTHROW;
 
 /**
  * Gets the double value of the live variable.
@@ -431,7 +431,7 @@ typedef NS_ENUM(NSInteger, OPTLYLiveVariableError) {
                   userId:(nonnull NSString *)userId
               attributes:(nullable NSDictionary *)attributes
       activateExperiment:(BOOL)activateExperiment
-                   error:(NSError * _Nullable * _Nullable)error;
+                   error:(out NSError * _Nullable * _Nullable)error NS_SWIFT_NOTHROW;
 
 @end
 

--- a/OptimizelySDKCore/OptimizelySDKCore/Optimizely.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/Optimizely.m
@@ -398,7 +398,7 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
                                userId:(nonnull NSString *)userId
                            attributes:(nullable NSDictionary *)attributes
                    activateExperiment:(BOOL)activateExperiment
-                                error:(NSError * _Nullable * _Nullable)error {
+                                error:(out NSError * _Nullable * _Nullable)error {
     return [self variableString:variableKey
                          userId:userId
                      attributes:attributes
@@ -524,7 +524,7 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
                  userId:(nonnull NSString *)userId
              attributes:(nullable NSDictionary *)attributes
      activateExperiment:(BOOL)activateExperiment
-                  error:(NSError * _Nullable * _Nullable)error {
+                  error:(out NSError * _Nullable * _Nullable)error {
     BOOL variableValue = false;
     NSString *variableValueStringOrNil = [self variableString:variableKey
                                                        userId:userId
@@ -573,7 +573,7 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
                       userId:(nonnull NSString *)userId
                   attributes:(nullable NSDictionary *)attributes
           activateExperiment:(BOOL)activateExperiment
-                       error:(NSError * _Nullable * _Nullable)error {
+                       error:(out NSError * _Nullable * _Nullable)error {
     NSInteger variableValue = 0;
     NSString *variableValueStringOrNil = [self variableString:variableKey
                                                        userId:userId
@@ -622,7 +622,7 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
                   userId:(nonnull NSString *)userId
               attributes:(nullable NSDictionary *)attributes
       activateExperiment:(BOOL)activateExperiment
-                   error:(NSError * _Nullable * _Nullable)error {
+                   error:(out NSError * _Nullable * _Nullable)error {
     double variableValue = 0.0;
     NSString *variableValueStringOrNil = [self variableString:variableKey
                                                        userId:userId


### PR DESCRIPTION
Add 'out' and 'NS_SWIFT_NOTHROW' to 4 variableXxx:...:error: declarations

Summary: OASIS-1359 Inconsistency in error parameter types for live variable getters

Test Plan:
./Scripts/local_travis.sh (slightly altered to 10.3.1 simulator) PASSED
on local machine AND "Show Completion List" dialog's view of the 4 variableXxx
error paramaters look consistent now.