### PR TITLE
Live Variable Error Handling Fix

### DIFF
--- a/OptimizelySDKCore/OptimizelySDKCore/Optimizely.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/Optimizely.m
@@ -404,8 +404,8 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
                      attributes:attributes
              activateExperiment:activateExperiment
                        callback:^(NSError *e) {
-                           if (e) {
-                               *error = e;
+                           if (error && e) {
+                                *error = e;
                            }
                        }];
 }

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
@@ -325,6 +325,23 @@ static NSString * const kVariationIDForWhitelisting = @"variation4";
     
     XCTAssertEqualObjects(variableString, kVariableStringValue, "Variable string value should be \"Hello\".");
 }
+- (void)testGetVariableStringWithError {
+    NSString *variableString = [self.optimizely variableString:@"invalidStringKey"
+                                                     userId:kUserId
+                                                 attributes:self.attributes
+                                         activateExperiment:NO
+                                                      error:nil];
+    XCTAssertNil(variableString);
+    
+    NSError *error = nil;
+    NSString *variableString2 = [self.optimizely variableString:@"invalidStringKey2"
+                                                        userId:kUserId
+                                                    attributes:self.attributes
+                                            activateExperiment:NO
+                                                         error:&error];
+    XCTAssertNil(variableString2);
+    XCTAssert(error.code == OPTLYLiveVariableErrorKeyUnknown);
+}
 
 #pragma mark - Live Variable Tests: variableBoolean
 - (void)testGetVariableBoolean {


### PR DESCRIPTION
Added a check to make sure error is provided before setting it. This was causing a crash if an error occurs and error is nil. Also added test to make sure this is always checked.