### PR TITLE
Fix 5 compiler warnings

### DIFF
--- a/OptimizelySDKShared/OptimizelySDKShared/OPTLYClient.m
+++ b/OptimizelySDKShared/OptimizelySDKShared/OPTLYClient.m
@@ -198,7 +198,7 @@
                                userId:(nonnull NSString *)userId
                            attributes:(nullable NSDictionary *)attributes
                    activateExperiment:(BOOL)activateExperiment
-                                error:(NSError * _Nullable * _Nullable)error {
+                                error:(out NSError * _Nullable * _Nullable)error {
     if (self.optimizely == nil) {
         [self.logger logMessage:OPTLYLoggerMessagesClientDummyOptimizelyError
                       withLevel:OptimizelyLogLevelError];
@@ -254,7 +254,7 @@
                  userId:(nonnull NSString *)userId
              attributes:(nullable NSDictionary *)attributes
      activateExperiment:(BOOL)activateExperiment
-                  error:(NSError * _Nullable * _Nullable)error {
+                  error:(out NSError * _Nullable * _Nullable)error {
     if (self.optimizely == nil) {
         [self.logger logMessage:OPTLYLoggerMessagesClientDummyOptimizelyError
                       withLevel:OptimizelyLogLevelError];
@@ -310,7 +310,7 @@
                       userId:(nonnull NSString *)userId
                   attributes:(nullable NSDictionary *)attributes
           activateExperiment:(BOOL)activateExperiment
-                       error:(NSError * _Nullable * _Nullable)error {
+                       error:(out NSError * _Nullable * _Nullable)error {
     if (self.optimizely == nil) {
         [self.logger logMessage:OPTLYLoggerMessagesClientDummyOptimizelyError
                       withLevel:OptimizelyLogLevelError];
@@ -366,7 +366,7 @@
                   userId:(nonnull NSString *)userId
               attributes:(nullable NSDictionary *)attributes
       activateExperiment:(BOOL)activateExperiment
-                   error:(NSError * _Nullable * _Nullable)error {
+                   error:(out NSError * _Nullable * _Nullable)error {
     if (self.optimizely == nil) {
         [self.logger logMessage:OPTLYLoggerMessagesClientDummyOptimizelyError
                       withLevel:OptimizelyLogLevelError];

--- a/OptimizelySDKShared/OptimizelySDKShared/OPTLYManagerBuilder.m
+++ b/OptimizelySDKShared/OptimizelySDKShared/OPTLYManagerBuilder.m
@@ -24,7 +24,7 @@
 #endif
 
 #import "OPTLYManagerBuilder.h"
-#import "OPTLYDatafilemanagerBasic.h"
+#import "OPTLYDatafileManagerBasic.h"
 
 @implementation OPTLYManagerBuilder
 


### PR DESCRIPTION
Summary: Fix 5 compiler warnings for upcomping 1.1.3 release.

Test Plan:
Buid OptimizelySDKiOS scheme.  There used to be 6 warnings.
Now there is 1 warning from JSONModel, which is not our code.
The iOS demo app still compiles and runs on "iPhone 6 (10.3.1)" simulator.

Reviewers: alda

JIRA Issues: OASIS-1359

Differential Revision: https://phabricator.optimizely.com/D16724