### PR TITLE
Kroach/oasis 1604 bugfix

### DIFF
--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYQueue.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYQueue.h
@@ -25,9 +25,9 @@ extern const NSInteger OPTLYQueueDefaultMaxSize;
 @interface OPTLYQueue : NSObject
 
 /// the queue
-@property (nonatomic, strong) NSArray *queue;
+@property (nonatomic, readonly, strong) NSArray *queue;
 /// the maximum size of the queue
-@property (nonatomic, assign) NSInteger maxQueueSize;
+@property (nonatomic, readonly, assign) NSInteger maxQueueSize;
 
 /*
  * Initializes the queue with a max size.

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYQueue.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYQueue.m
@@ -19,34 +19,54 @@
 const NSInteger OPTLYQueueDefaultMaxSize = 1000;
 
 @interface OPTLYQueue()
+@property (nonatomic, strong) NSArray *queue;
+@property (nonatomic, assign) NSInteger maxQueueSize;
 @property (nonatomic, strong) NSMutableArray *mutableQueue;
+@property (nonatomic, strong) NSObject *lockObject;
 @end
 
 @implementation OPTLYQueue
 
-- (id)init {
-    self = [super init];
-    if (self) {
-        _maxQueueSize = OPTLYQueueDefaultMaxSize;
-        _mutableQueue = [[NSMutableArray alloc] initWithCapacity:_maxQueueSize];
+#pragma mark - Properties
+// Thread-safe getters and setters for mutable public properties
+
+- (NSArray *)queue {
+    // queue is reaadonly property
+    @synchronized (_lockObject) {
+        return [self.mutableQueue copy];
     }
-    return self;
+}
+
+// maxQueueSize is immutable reaadonly property
+
+// mutableQueue is hidden encapsulated property
+
+#pragma mark - Life Cycle
+
+- (id)init {
+    return [self initWithQueueSize:OPTLYQueueDefaultMaxSize];
 }
 
 - (instancetype)initWithQueueSize:(NSInteger)maxQueueSize {
+    // Designated Initializer
     self = [super init];
     if (self) {
         _maxQueueSize = maxQueueSize;
         _mutableQueue = [[NSMutableArray alloc] initWithCapacity:_maxQueueSize];
+        _lockObject = [[NSObject alloc] init];
     }
     return self;
 }
 
+#pragma mark - Operations
+
 - (bool)enqueue:(id)data {
-    if (!self.isFull) {
-        if (data) {
-            [self.mutableQueue addObject:data];
-            return true;
+    @synchronized (_lockObject) {
+        if (!self.isFull) {
+            if (data) {
+                [self.mutableQueue addObject:data];
+                return true;
+            }
         }
     }
     return false;
@@ -54,64 +74,76 @@ const NSInteger OPTLYQueueDefaultMaxSize = 1000;
 
 - (id)front {
     id item = nil;
-    if (!self.isEmpty) {
-        item = [self.mutableQueue objectAtIndex:0];
+    @synchronized (_lockObject) {
+        if (!self.isEmpty) {
+            item = [self.mutableQueue objectAtIndex:0];
+        }
     }
     return item;
 }
 
 - (NSArray *)firstNItems:(NSInteger)numberOfItems {
     NSArray *items;
-    if (!self.isEmpty) {
-        NSInteger endOfRange = numberOfItems > [self size] ? [self size] : numberOfItems;
-        NSRange range = NSMakeRange(0, endOfRange);
-        items = [self.mutableQueue subarrayWithRange:range];
+    @synchronized (_lockObject) {
+        if (!self.isEmpty) {
+            NSInteger endOfRange = numberOfItems > [self size] ? [self size] : numberOfItems;
+            NSRange range = NSMakeRange(0, endOfRange);
+            items = [self.mutableQueue subarrayWithRange:range];
+        }
     }
     return items;
 }
 
 - (id)dequeue {
     id item = nil;
-    if (!self.isEmpty) {
-        item = [self.mutableQueue objectAtIndex:0];
-        [self.mutableQueue removeObject:item];
+    @synchronized (_lockObject) {
+        if (!self.isEmpty) {
+            item = [self.mutableQueue objectAtIndex:0];
+            [self.mutableQueue removeObject:item];
+        }
     }
     return item;
 }
 
 - (NSArray *)dequeueNItems:(NSInteger)numberOfItems {
     NSArray *items;
-    if (!self.isEmpty) {
-        NSInteger endOfRange = numberOfItems > [self size] ? [self size] : numberOfItems;
-        NSRange range = NSMakeRange(0, endOfRange);
-        items = [self.mutableQueue subarrayWithRange:range];
-        [self.mutableQueue removeObjectsInRange:range];
+    @synchronized (_lockObject) {
+        if (!self.isEmpty) {
+            NSInteger endOfRange = numberOfItems > [self size] ? [self size] : numberOfItems;
+            NSRange range = NSMakeRange(0, endOfRange);
+            items = [self.mutableQueue subarrayWithRange:range];
+            [self.mutableQueue removeObjectsInRange:range];
+        }
     }
     return items;
 }
 
 - (void)removeItem:(id)item {
-    for (NSInteger i = 0; i < [self size]; ++i) {
-        if ([item isEqual:self.mutableQueue[i]]) {
-            [self.mutableQueue removeObjectAtIndex:i];
+    @synchronized (_lockObject) {
+        for (NSInteger i = [self size]-1; i >= 0; i--) {
+            if ([item isEqual:self.mutableQueue[i]]) {
+                [self.mutableQueue removeObjectAtIndex:i];
+            }
         }
     }
 }
 
 - (NSInteger)size {
-    return [self.mutableQueue count];
+    @synchronized (_lockObject) {
+        return [self.mutableQueue count];
+    }
 }
 
 - (bool)isFull {
-    return ([self.mutableQueue count] >= self.maxQueueSize);
+    @synchronized (_lockObject) {
+        return ([self.mutableQueue count] >= self.maxQueueSize);
+    }
 }
 
 - (bool)isEmpty {
-    return [self.mutableQueue count] == 0;
-}
-
-- (NSArray *)queue {
-    return [self.mutableQueue copy];
+    @synchronized (_lockObject) {
+        return [self.mutableQueue count] == 0;
+    }
 }
 
 @end

--- a/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher.xcodeproj/project.pbxproj
+++ b/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher.xcodeproj/project.pbxproj
@@ -11,6 +11,10 @@
 		3E0027511ECBBE5F0072DDAD /* Pods_OptimizelySDKSharediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E0027501ECBBE5F0072DDAD /* Pods_OptimizelySDKSharediOS.framework */; };
 		3E0027551ECBBE950072DDAD /* OptimizelySDKUserProfileService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E0027541ECBBE950072DDAD /* OptimizelySDKUserProfileService.framework */; };
 		3E0027571ECBBEB10072DDAD /* OptimizelySDKUserProfileService.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E0027561ECBBEB10072DDAD /* OptimizelySDKUserProfileService.framework */; };
+		3E2B00BD1F27AE18004F66E9 /* OPTLYMutableSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E2B00BB1F27AE18004F66E9 /* OPTLYMutableSet.h */; };
+		3E2B00BE1F27AE18004F66E9 /* OPTLYMutableSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E2B00BB1F27AE18004F66E9 /* OPTLYMutableSet.h */; };
+		3E2B00BF1F27AE18004F66E9 /* OPTLYMutableSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E2B00BC1F27AE18004F66E9 /* OPTLYMutableSet.m */; };
+		3E2B00C01F27AE18004F66E9 /* OPTLYMutableSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E2B00BC1F27AE18004F66E9 /* OPTLYMutableSet.m */; };
 		54770275047095CC925FC46E /* Pods_OptimizelySDKEventDispatcheriOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE3E25CA29BD3B84317654DD /* Pods_OptimizelySDKEventDispatcheriOSTests.framework */; };
 		88620F49A57781AD90653E9C /* Pods_OptimizelySDKEventDispatcheriOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EFE3CCF1E529546113D4F010 /* Pods_OptimizelySDKEventDispatcheriOS.framework */; };
 		DF8C6B377B170C031FF71C57 /* Pods_OptimizelySDKEventDispatcherTVOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E69AAECF8B785E459CC3BFA9 /* Pods_OptimizelySDKEventDispatcherTVOSTests.framework */; };
@@ -101,6 +105,8 @@
 		3E0027501ECBBE5F0072DDAD /* Pods_OptimizelySDKSharediOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Pods_OptimizelySDKSharediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3E0027541ECBBE950072DDAD /* OptimizelySDKUserProfileService.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OptimizelySDKUserProfileService.framework; path = "../../Library/Developer/Xcode/DerivedData/OptimizelySDK-exeyzvnfpwxywqafentqnxughgiy/Build/Products/Debug-iphoneos/OptimizelySDKUserProfileService.framework"; sourceTree = "<group>"; };
 		3E0027561ECBBEB10072DDAD /* OptimizelySDKUserProfileService.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OptimizelySDKUserProfileService.framework; path = "../../Library/Developer/Xcode/DerivedData/OptimizelySDK-exeyzvnfpwxywqafentqnxughgiy/Build/Products/Debug-appletvos/OptimizelySDKUserProfileService.framework"; sourceTree = "<group>"; };
+		3E2B00BB1F27AE18004F66E9 /* OPTLYMutableSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OPTLYMutableSet.h; sourceTree = "<group>"; };
+		3E2B00BC1F27AE18004F66E9 /* OPTLYMutableSet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OPTLYMutableSet.m; sourceTree = "<group>"; };
 		4B2747E0A19EA244FD34A0B2 /* Pods-OptimizelySDKEventDispatcherTVOS.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OptimizelySDKEventDispatcherTVOS.beta.xcconfig"; path = "../Pods/Target Support Files/Pods-OptimizelySDKEventDispatcherTVOS/Pods-OptimizelySDKEventDispatcherTVOS.beta.xcconfig"; sourceTree = "<group>"; };
 		4BF934501CBCB2643883E1D7 /* Pods-OptimizelySDKEventDispatcheriOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OptimizelySDKEventDispatcheriOS.release.xcconfig"; path = "../Pods/Target Support Files/Pods-OptimizelySDKEventDispatcheriOS/Pods-OptimizelySDKEventDispatcheriOS.release.xcconfig"; sourceTree = "<group>"; };
 		55C9A855C92A29B591DAA300 /* Pods-OptimizelySDKEventDispatcheriOSTests.rc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OptimizelySDKEventDispatcheriOSTests.rc.xcconfig"; path = "../Pods/Target Support Files/Pods-OptimizelySDKEventDispatcheriOSTests/Pods-OptimizelySDKEventDispatcheriOSTests.rc.xcconfig"; sourceTree = "<group>"; };
@@ -231,6 +237,8 @@
 				EA52493E1DC72F8400AF6685 /* OPTLYEventDispatcher.m */,
 				EA29D8EF1DCAC2410034A4FE /* OPTLYEventDispatcherBuilder.h */,
 				EA29D8F01DCAC2410034A4FE /* OPTLYEventDispatcherBuilder.m */,
+				3E2B00BB1F27AE18004F66E9 /* OPTLYMutableSet.h */,
+				3E2B00BC1F27AE18004F66E9 /* OPTLYMutableSet.m */,
 			);
 			path = OptimizelySDKEventDispatcher;
 			sourceTree = "<group>";
@@ -278,6 +286,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EA52493F1DC72F8400AF6685 /* OPTLYEventDispatcher.h in Headers */,
+				3E2B00BD1F27AE18004F66E9 /* OPTLYMutableSet.h in Headers */,
 				EA52499F1DC7D91800AF6685 /* OptimizelySDKEventDispatcher.h in Headers */,
 				EA29D8F11DCAC2410034A4FE /* OPTLYEventDispatcherBuilder.h in Headers */,
 			);
@@ -288,6 +297,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EA5249C31DC7DD5500AF6685 /* OPTLYEventDispatcher.h in Headers */,
+				3E2B00BE1F27AE18004F66E9 /* OPTLYMutableSet.h in Headers */,
 				EA5249EC1DC7E76400AF6685 /* OptimizelySDKEventDispatcher.h in Headers */,
 				EA29D8F21DCAC2410034A4FE /* OPTLYEventDispatcherBuilder.h in Headers */,
 			);
@@ -657,6 +667,7 @@
 			files = (
 				EA29D8F31DCAC2410034A4FE /* OPTLYEventDispatcherBuilder.m in Sources */,
 				EA5249411DC72F8400AF6685 /* OPTLYEventDispatcher.m in Sources */,
+				3E2B00BF1F27AE18004F66E9 /* OPTLYMutableSet.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -674,6 +685,7 @@
 			files = (
 				EA29D8F41DCAC2410034A4FE /* OPTLYEventDispatcherBuilder.m in Sources */,
 				EA5249C21DC7DD4A00AF6685 /* OPTLYEventDispatcher.m in Sources */,
+				3E2B00C01F27AE18004F66E9 /* OPTLYMutableSet.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher.xcodeproj/project.pbxproj
+++ b/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		3E2B00BE1F27AE18004F66E9 /* OPTLYMutableSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E2B00BB1F27AE18004F66E9 /* OPTLYMutableSet.h */; };
 		3E2B00BF1F27AE18004F66E9 /* OPTLYMutableSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E2B00BC1F27AE18004F66E9 /* OPTLYMutableSet.m */; };
 		3E2B00C01F27AE18004F66E9 /* OPTLYMutableSet.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E2B00BC1F27AE18004F66E9 /* OPTLYMutableSet.m */; };
+		3EBEC6461F27EFD70012797B /* OPTLYMutableSetTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EBEC6451F27EFD70012797B /* OPTLYMutableSetTest.m */; };
+		3EBEC6471F27EFD70012797B /* OPTLYMutableSetTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 3EBEC6451F27EFD70012797B /* OPTLYMutableSetTest.m */; };
 		54770275047095CC925FC46E /* Pods_OptimizelySDKEventDispatcheriOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DE3E25CA29BD3B84317654DD /* Pods_OptimizelySDKEventDispatcheriOSTests.framework */; };
 		88620F49A57781AD90653E9C /* Pods_OptimizelySDKEventDispatcheriOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EFE3CCF1E529546113D4F010 /* Pods_OptimizelySDKEventDispatcheriOS.framework */; };
 		DF8C6B377B170C031FF71C57 /* Pods_OptimizelySDKEventDispatcherTVOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E69AAECF8B785E459CC3BFA9 /* Pods_OptimizelySDKEventDispatcherTVOSTests.framework */; };
@@ -107,6 +109,7 @@
 		3E0027561ECBBEB10072DDAD /* OptimizelySDKUserProfileService.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OptimizelySDKUserProfileService.framework; path = "../../Library/Developer/Xcode/DerivedData/OptimizelySDK-exeyzvnfpwxywqafentqnxughgiy/Build/Products/Debug-appletvos/OptimizelySDKUserProfileService.framework"; sourceTree = "<group>"; };
 		3E2B00BB1F27AE18004F66E9 /* OPTLYMutableSet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OPTLYMutableSet.h; sourceTree = "<group>"; };
 		3E2B00BC1F27AE18004F66E9 /* OPTLYMutableSet.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OPTLYMutableSet.m; sourceTree = "<group>"; };
+		3EBEC6451F27EFD70012797B /* OPTLYMutableSetTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OPTLYMutableSetTest.m; sourceTree = "<group>"; };
 		4B2747E0A19EA244FD34A0B2 /* Pods-OptimizelySDKEventDispatcherTVOS.beta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OptimizelySDKEventDispatcherTVOS.beta.xcconfig"; path = "../Pods/Target Support Files/Pods-OptimizelySDKEventDispatcherTVOS/Pods-OptimizelySDKEventDispatcherTVOS.beta.xcconfig"; sourceTree = "<group>"; };
 		4BF934501CBCB2643883E1D7 /* Pods-OptimizelySDKEventDispatcheriOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OptimizelySDKEventDispatcheriOS.release.xcconfig"; path = "../Pods/Target Support Files/Pods-OptimizelySDKEventDispatcheriOS/Pods-OptimizelySDKEventDispatcheriOS.release.xcconfig"; sourceTree = "<group>"; };
 		55C9A855C92A29B591DAA300 /* Pods-OptimizelySDKEventDispatcheriOSTests.rc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OptimizelySDKEventDispatcheriOSTests.rc.xcconfig"; path = "../Pods/Target Support Files/Pods-OptimizelySDKEventDispatcheriOSTests/Pods-OptimizelySDKEventDispatcheriOSTests.rc.xcconfig"; sourceTree = "<group>"; };
@@ -248,6 +251,7 @@
 			children = (
 				EA29D8F81DCB23750034A4FE /* OptimizelySDKEventDispatcherTests-Info.plist */,
 				EA52495E1DC7B4FE00AF6685 /* OPTLYEventDispatcherTest.m */,
+				3EBEC6451F27EFD70012797B /* OPTLYMutableSetTest.m */,
 			);
 			path = OptimizelySDKEventDispatcherTests;
 			sourceTree = "<group>";
@@ -675,6 +679,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3EBEC6461F27EFD70012797B /* OPTLYMutableSetTest.m in Sources */,
 				EA5249661DC7BA0800AF6685 /* OPTLYEventDispatcherTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -693,6 +698,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3EBEC6471F27EFD70012797B /* OPTLYMutableSetTest.m in Sources */,
 				EA87A00B1DDE7356002E9EF7 /* OPTLYEventDispatcherTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher/OPTLYEventDispatcher.m
+++ b/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher/OPTLYEventDispatcher.m
@@ -19,6 +19,7 @@
     #import <OptimizelySDKCore/OPTLYNetworkService.h>
 #endif
 #import "OPTLYEventDispatcher.h"
+#import "OPTLYMutableSet.h"
 
 // TODO - Flush events when network connection has become available.
 
@@ -39,7 +40,7 @@ const NSInteger OPTLYEventDispatcherDefaultMaxNumberOfEventsToSave = 1000;
 @property (nonatomic, strong) OPTLYDataStore *dataStore;
 @property (nonatomic, strong) NSTimer *timer;
 @property (nonatomic, strong) OPTLYNetworkService *networkService;
-@property (nonatomic, strong) NSMutableSet *pendingDispatchEvents;
+@property (nonatomic, strong) OPTLYMutableSet *pendingDispatchEvents;
 @property (nonatomic, assign) NSInteger flushEventAttempts;
 @end
 
@@ -59,7 +60,7 @@ const NSInteger OPTLYEventDispatcherDefaultMaxNumberOfEventsToSave = 1000;
         _flushEventAttempts = 0;
         _timer = nil;
         _eventDispatcherDispatchInterval = OPTLYEventDispatcherDefaultDispatchIntervalTime_s;
-        _pendingDispatchEvents = [NSMutableSet new];
+        _pendingDispatchEvents = [OPTLYMutableSet new];
         _logger = builder.logger;
         _maxNumberOfEventsToSave = OPTLYEventDispatcherDefaultMaxNumberOfEventsToSave;
         if (builder.maxNumberOfEventsToSave > 0) {

--- a/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher/OPTLYMutableSet.h
+++ b/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher/OPTLYMutableSet.h
@@ -1,0 +1,15 @@
+//
+//  OPTLYMutableSet.h
+//  OptimizelySDKEventDispatcher
+//
+//  Created by Kelly Roach on 7/25/17.
+//  Copyright © 2017 Optimizely. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface OPTLYMutableSet<ObjectType> : NSObject
+- (BOOL)containsObject:(ObjectType)anObject;
+- (void)addObject:(ObjectType)object;
+- (void)removeObject:(ObjectType)object;
+@end

--- a/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher/OPTLYMutableSet.h
+++ b/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher/OPTLYMutableSet.h
@@ -9,7 +9,9 @@
 #import <Foundation/Foundation.h>
 
 @interface OPTLYMutableSet<ObjectType> : NSObject
+@property(readonly) NSUInteger count;
 - (BOOL)containsObject:(ObjectType)anObject;
 - (void)addObject:(ObjectType)object;
 - (void)removeObject:(ObjectType)object;
+- (void)removeAllObjects;
 @end

--- a/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher/OPTLYMutableSet.m
+++ b/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher/OPTLYMutableSet.m
@@ -29,6 +29,11 @@
     }
     return self;
 }
+- (NSUInteger)count {
+    @synchronized (_lockObject) {
+        return [_mutableSet count];
+    }
+}
 - (BOOL)containsObject:(id)anObject {
     BOOL answer=NO;
     @synchronized (_lockObject) {
@@ -44,6 +49,11 @@
 - (void)removeObject:(id)object {
     @synchronized (_lockObject) {
         [_mutableSet removeObject:object];
+    }
+}
+- (void)removeAllObjects {
+    @synchronized (_lockObject) {
+        [_mutableSet removeAllObjects];
     }
 }
 @end

--- a/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher/OPTLYMutableSet.m
+++ b/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher/OPTLYMutableSet.m
@@ -1,0 +1,49 @@
+//
+//  OPTLYMutableSet.m
+//  OptimizelySDKEventDispatcher
+//
+//  Created by Kelly Roach on 7/25/17.
+//  Copyright © 2017 Optimizely. All rights reserved.
+//
+
+#import "OPTLYMutableSet.h"
+
+/*
+ * This class implements a thread-safe wrapper around NSMutableSet that
+ * is used by OPTLYEventDispatcher.m .  We only implement the NSMutableSet
+ * methods OPTLYEventDispatcher.m needs, but more could be added later if
+ * there is demand.
+ */
+
+@interface OPTLYMutableSet<ObjectType> ()
+@property (nonatomic,strong) NSObject *lockObject;
+@property (nonatomic,strong) NSMutableSet *mutableSet;
+@end
+
+@implementation OPTLYMutableSet
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _lockObject = [[NSObject alloc] init];
+        _mutableSet = [[NSMutableSet alloc] init];
+    }
+    return self;
+}
+- (BOOL)containsObject:(id)anObject {
+    BOOL answer=NO;
+    @synchronized (_lockObject) {
+        answer=[_mutableSet containsObject:anObject];
+    }
+    return answer;
+}
+- (void)addObject:(id)object {
+    @synchronized (_lockObject) {
+        [_mutableSet addObject:object];
+    }
+}
+- (void)removeObject:(id)object {
+    @synchronized (_lockObject) {
+        [_mutableSet removeObject:object];
+    }
+}
+@end

--- a/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcherTests/OPTLYMutableSetTest.m
+++ b/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcherTests/OPTLYMutableSetTest.m
@@ -1,0 +1,92 @@
+//
+//  OPTLYMutableSetTest.m
+//  OptimizelySDKEventDispatcher
+//
+//  Created by Kelly Roach on 7/25/17.
+//  Copyright © 2017 Optimizely. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "OPTLYMutableSet.h"
+
+@interface OPTLYMutableSetTest : XCTestCase
+
+@end
+
+@implementation OPTLYMutableSetTest
+
+- (void)testOPTLYMutableSetAPI {
+    // Confirm OPTLYMutableSet behaves like NSMutableSet wrt declared API methods.
+    // Begin with empty set.
+    OPTLYMutableSet *mutableSet=[OPTLYMutableSet new];
+    NSString *x=@"x";
+    NSString *y=@"y";
+    NSString *z=@"z";
+    XCTAssertEqual(mutableSet.count, 0, @"mutableSet should be empty");
+    XCTAssertEqual([mutableSet count], 0, @"mutableSet should be empty");
+    XCTAssertFalse([mutableSet containsObject:x], @"mutableSet shouldn't contain x");
+    XCTAssertFalse([mutableSet containsObject:y], @"mutableSet shouldn't contain y");
+    XCTAssertFalse([mutableSet containsObject:z], @"mutableSet shouldn't contain z");
+    // Add element x .
+    [mutableSet addObject:x];
+    XCTAssertEqual(mutableSet.count, 1, @"mutableSet should be {x}");
+    XCTAssertEqual([mutableSet count], 1, @"mutableSet should be {x}");
+    XCTAssert([mutableSet containsObject:x], @"mutableSet should contain x");
+    XCTAssertFalse([mutableSet containsObject:y], @"mutableSet shouldn't contain y");
+    XCTAssertFalse([mutableSet containsObject:z], @"mutableSet shouldn't contain z");
+    // Add element x again .
+    [mutableSet addObject:x];
+    XCTAssertEqual(mutableSet.count, 1, @"mutableSet should be {x}");
+    XCTAssertEqual([mutableSet count], 1, @"mutableSet should be {x}");
+    XCTAssert([mutableSet containsObject:x], @"mutableSet should contain x");
+    XCTAssertFalse([mutableSet containsObject:y], @"mutableSet shouldn't contain y");
+    XCTAssertFalse([mutableSet containsObject:z], @"mutableSet shouldn't contain z");
+    // Add element y .
+    [mutableSet addObject:y];
+    XCTAssertEqual(mutableSet.count, 2, @"mutableSet should be {x, y}");
+    XCTAssertEqual([mutableSet count], 2, @"mutableSet should be {x, y}");
+    XCTAssert([mutableSet containsObject:x], @"mutableSet should contain x");
+    XCTAssert([mutableSet containsObject:y], @"mutableSet should contain y");
+    XCTAssertFalse([mutableSet containsObject:z], @"mutableSet shouldn't contain z");
+    // Add element z .
+    [mutableSet addObject:z];
+    XCTAssertEqual(mutableSet.count, 3, @"mutableSet should be {x, y}");
+    XCTAssertEqual([mutableSet count], 3, @"mutableSet should be {x, y}");
+    XCTAssert([mutableSet containsObject:x], @"mutableSet should contain x");
+    XCTAssert([mutableSet containsObject:y], @"mutableSet should contain y");
+    XCTAssert([mutableSet containsObject:z], @"mutableSet should contain z");
+    // Add element z again .
+    [mutableSet addObject:z];
+    XCTAssertEqual(mutableSet.count, 3, @"mutableSet should be {x, y}");
+    XCTAssertEqual([mutableSet count], 3, @"mutableSet should be {x, y}");
+    XCTAssert([mutableSet containsObject:x], @"mutableSet should contain x");
+    XCTAssert([mutableSet containsObject:y], @"mutableSet should contain y");
+    XCTAssert([mutableSet containsObject:z], @"mutableSet should contain z");
+    // Remove element x . State should be two element set {y, z} .
+    [mutableSet removeObject:x];
+    XCTAssertEqual(mutableSet.count, 2, @"mutableSet should be {y, z}");
+    XCTAssertEqual([mutableSet count], 2, @"mutableSet should be {y, z}");
+    XCTAssertFalse([mutableSet containsObject:x], @"mutableSet shouldn't contain x");
+    XCTAssert([mutableSet containsObject:y], @"mutableSet should contain y");
+    XCTAssert([mutableSet containsObject:z], @"mutableSet should contain z");
+    // Remove element x when not present acts like a NOP .
+    [mutableSet removeObject:x];
+    XCTAssertEqual(mutableSet.count, 2, @"mutableSet should be {y, z}");
+    XCTAssertEqual([mutableSet count], 2, @"mutableSet should be {y, z}");
+    // Remove all elements . State should be empty set {} .
+    [mutableSet removeAllObjects];
+    XCTAssertEqual(mutableSet.count, 0, @"mutableSet should be empty");
+    XCTAssertEqual([mutableSet count], 0, @"mutableSet should be empty");
+    XCTAssertFalse([mutableSet containsObject:x], @"mutableSet shouldn't contain x");
+    XCTAssertFalse([mutableSet containsObject:y], @"mutableSet shouldn't contain y");
+    XCTAssertFalse([mutableSet containsObject:z], @"mutableSet shouldn't contain z");
+    // Add element x .
+    [mutableSet addObject:x];
+    XCTAssertEqual(mutableSet.count, 1, @"mutableSet should be {x}");
+    XCTAssertEqual([mutableSet count], 1, @"mutableSet should be {x}");
+    XCTAssert([mutableSet containsObject:x], @"mutableSet should contain x");
+    XCTAssertFalse([mutableSet containsObject:y], @"mutableSet shouldn't contain y");
+    XCTAssertFalse([mutableSet containsObject:z], @"mutableSet shouldn't contain z");
+}
+
+@end

--- a/OptimizelySDKShared/OptimizelySDKShared/OPTLYEventDataStore.m
+++ b/OptimizelySDKShared/OptimizelySDKShared/OPTLYEventDataStore.m
@@ -173,7 +173,7 @@ dispatch_queue_t eventsStorageCacheQueue()
         eventType:(nonnull NSString *)eventTypeName
             error:(NSError * _Nullable * _Nullable)error
 {
-    dispatch_async(eventsStorageCacheQueue(), ^{
+    dispatch_barrier_async(eventsStorageCacheQueue(), ^{
         __weak typeof(self) weakSelf = self;
         OPTLYQueue *queue = [weakSelf.eventsCache objectForKey:eventTypeName];
         [queue enqueue:data];
@@ -198,7 +198,7 @@ dispatch_queue_t eventsStorageCacheQueue()
                  eventType:(nonnull NSString *)eventTypeName
                      error:(NSError * _Nullable * _Nullable)error
 {
-    dispatch_async(eventsStorageCacheQueue(), ^{
+    dispatch_barrier_async(eventsStorageCacheQueue(), ^{
         __weak typeof(self) weakSelf = self;
         OPTLYQueue *queue = [weakSelf.eventsCache objectForKey:eventTypeName];
         [queue dequeueNItems:numberOfEvents];
@@ -209,7 +209,7 @@ dispatch_queue_t eventsStorageCacheQueue()
           eventType:(nonnull NSString *)eventTypeName
               error:(NSError * _Nullable * _Nullable)error
 {
-    dispatch_async(eventsStorageCacheQueue(), ^{
+    dispatch_barrier_async(eventsStorageCacheQueue(), ^{
         __weak typeof(self) weakSelf = self;
         OPTLYQueue *queue = [weakSelf.eventsCache objectForKey:eventTypeName];
         [queue removeItem:event];


### PR DESCRIPTION
OASIS-1604 Intermittent crash

Fix intermittent crash in OPTLYEventDispatcher.m code. We believe the root cause was imperfect thread safety in the OPTLYEventDispatcher.m's dispatchEvent:backoffRetry:eventType:callback access of an NSMutableSet *pendingDispatchEvents .  The remedy is to convert this into a thread-safe OPTLYMutableSet *pendingDispatchEvents . We're including thread safety improvements to OPTLYQueue.m+.h and OPTLYEventDataStore.m too.  These 2 classes had their own "Mutable" objects which looked like they needed more thread safety.
