### PR TITLE
Kroach/oasis 1614 extapi 11x

### DIFF
--- a/OptimizelyDemoApp/OptimizelyDemoApp.xcodeproj/project.pbxproj
+++ b/OptimizelyDemoApp/OptimizelyDemoApp.xcodeproj/project.pbxproj
@@ -820,7 +820,7 @@
 					"\"${PODS_ROOT}/FirebaseCore/Frameworks\"",
 					"\"${PODS_ROOT}/FirebaseInstanceID/Frameworks\"",
 					"\"${PODS_ROOT}/Google/Frameworks\"",
-					"\"${PODS_ROOT}/Localytics/Localytics-iOS-4.2.0\"",
+					"\"${PODS_ROOT}/Localytics/Localytics-iOS-4.3.0\"",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/OptimizelyiOSDemoApp/OptimizelyiOSDemoApp-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;

--- a/OptimizelySDKCore/OptimizelySDKCore.xcodeproj/project.pbxproj
+++ b/OptimizelySDKCore/OptimizelySDKCore.xcodeproj/project.pbxproj
@@ -1434,6 +1434,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 944729689803E993C9DC6D54 /* Pods-OptimizelySDKCoreiOS.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1464,6 +1465,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 535C603DDFD996B277A0E064 /* Pods-OptimizelySDKCoreiOS.rc.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1490,6 +1492,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D4195831840B6A255A7E0EB9 /* Pods-OptimizelySDKCoreiOS.beta.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1516,6 +1519,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 01386A41636DEDC5D8938455 /* Pods-OptimizelySDKCoreiOS.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1606,6 +1610,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F6CC17F155793CF43AB7A3D9 /* Pods-OptimizelySDKCoreTVOS.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1636,6 +1641,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3FBA850033BBEC39D85B617B /* Pods-OptimizelySDKCoreTVOS.rc.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1662,6 +1668,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4AD98EC23436656DED35EBED /* Pods-OptimizelySDKCoreTVOS.beta.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1688,6 +1695,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B0B2C5870F0F8E1FDD2E1FCD /* Pods-OptimizelySDKCoreTVOS.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;

--- a/OptimizelySDKDatafileManager/OptimizelySDKDatafileManager.xcodeproj/project.pbxproj
+++ b/OptimizelySDKDatafileManager/OptimizelySDKDatafileManager.xcodeproj/project.pbxproj
@@ -998,6 +998,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BB5AA95983AE702D0CF7A143 /* Pods-OptimizelySDKDatafileManageriOS.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1026,6 +1027,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E07A16C7EA91C9D0B85F91C4 /* Pods-OptimizelySDKDatafileManageriOS.rc .xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1050,6 +1052,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 61B1B0086825F3982EF1AF60 /* Pods-OptimizelySDKDatafileManageriOS.beta.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1074,6 +1077,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 00E229D537533B61E486FD74 /* Pods-OptimizelySDKDatafileManageriOS.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1162,6 +1166,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 014E0B036FDB9D48F093B283 /* Pods-OptimizelySDKDatafileManagerTVOS.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1192,6 +1197,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B1DE3E3685940C8A1F4EBAF9 /* Pods-OptimizelySDKDatafileManagerTVOS.rc .xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1218,6 +1224,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 71640A874978C2BA42C98562 /* Pods-OptimizelySDKDatafileManagerTVOS.beta.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1244,6 +1251,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B2819F4E5016E1005D9A2D8D /* Pods-OptimizelySDKDatafileManagerTVOS.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;

--- a/OptimizelySDKDatafileManager/OptimizelySDKDatafileManager/OPTLYDatafileManager.m
+++ b/OptimizelySDKDatafileManager/OptimizelySDKDatafileManager/OPTLYDatafileManager.m
@@ -185,27 +185,25 @@ NSTimeInterval const kDefaultDatafileFetchInterval_s = 120;
 #pragma mark - Application Lifecycle Handlers
 - (void)setupApplicationNotificationHandlers {
     NSNotificationCenter *defaultCenter = [NSNotificationCenter defaultCenter];
-    UIApplication *app = [UIApplication sharedApplication];
-    
     [defaultCenter addObserver:self
                       selector:@selector(applicationDidFinishLaunching:)
                           name:UIApplicationDidFinishLaunchingNotification
-                        object:app];
+                        object:nil];
     
     [defaultCenter addObserver:self
                       selector:@selector(applicationDidBecomeActive:)
                           name:UIApplicationDidBecomeActiveNotification
-                        object:app];
+                        object:nil];
     
     [defaultCenter addObserver:self
                       selector:@selector(applicationDidEnterBackground:)
                           name:UIApplicationDidEnterBackgroundNotification
-                        object:app];
+                        object:nil];
     
     [defaultCenter addObserver:self
                       selector:@selector(applicationWillTerminate:)
                           name:UIApplicationWillTerminateNotification
-                        object:app];
+                        object:nil];
 }
 
 - (void)applicationDidFinishLaunching:(id)notificaton {

--- a/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher.xcodeproj/project.pbxproj
+++ b/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher.xcodeproj/project.pbxproj
@@ -941,6 +941,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2BC91A746D5460CAC2179173 /* Pods-OptimizelySDKEventDispatcheriOS.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -969,6 +970,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = EEEA573DC462834DA4D553BD /* Pods-OptimizelySDKEventDispatcheriOS.beta.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -993,6 +995,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1830BCB500C3131410C5185B /* Pods-OptimizelySDKEventDispatcheriOS.rc.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1017,6 +1020,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4BF934501CBCB2643883E1D7 /* Pods-OptimizelySDKEventDispatcheriOS.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1105,6 +1109,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9F44E187F0307E7E4658DE61 /* Pods-OptimizelySDKEventDispatcherTVOS.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CODE_SIGN_IDENTITY = "";
@@ -1134,6 +1139,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4B2747E0A19EA244FD34A0B2 /* Pods-OptimizelySDKEventDispatcherTVOS.beta.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CODE_SIGN_IDENTITY = "";
@@ -1159,6 +1165,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FCB98CEB5A64A0C856A5C2B5 /* Pods-OptimizelySDKEventDispatcherTVOS.rc.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CODE_SIGN_IDENTITY = "";
@@ -1184,6 +1191,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 242A387AE2F177A4BEF851CB /* Pods-OptimizelySDKEventDispatcherTVOS.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				CODE_SIGN_IDENTITY = "";

--- a/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher/OPTLYEventDispatcher.m
+++ b/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher/OPTLYEventDispatcher.m
@@ -377,37 +377,36 @@ dispatch_queue_t dispatchEventQueue()
 
 - (void)setupApplicationNotificationHandlers {
     NSNotificationCenter *defaultCenter = [NSNotificationCenter defaultCenter];
-    UIApplication *app = [UIApplication sharedApplication];
     
     [defaultCenter addObserver:self
                       selector:@selector(applicationDidFinishLaunching:)
                           name:UIApplicationDidFinishLaunchingNotification
-                        object:app];
+                        object:nil];
     
     [defaultCenter addObserver:self
                       selector:@selector(applicationDidBecomeActive:)
                           name:UIApplicationDidBecomeActiveNotification
-                        object:app];
+                        object:nil];
     
     [defaultCenter addObserver:self
                       selector:@selector(applicationDidEnterBackground:)
                           name:UIApplicationDidEnterBackgroundNotification
-                        object:app];
+                        object:nil];
     
     [defaultCenter addObserver:self
                       selector:@selector(applicationWillEnterForeground:)
                           name:UIApplicationWillEnterForegroundNotification
-                        object:app];
+                        object:nil];
     
     [defaultCenter addObserver:self
                       selector:@selector(applicationWillResignActive:)
                           name:UIApplicationWillResignActiveNotification
-                        object:app];
+                        object:nil];
     
     [defaultCenter addObserver:self
                       selector:@selector(applicationWillTerminate:)
                           name:UIApplicationWillTerminateNotification
-                        object:app];
+                        object:nil];
 }
 
 

--- a/OptimizelySDKShared/OptimizelySDKShared.xcodeproj/project.pbxproj
+++ b/OptimizelySDKShared/OptimizelySDKShared.xcodeproj/project.pbxproj
@@ -1159,6 +1159,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 202293A05EDCEE1B7C19C05B /* Pods-OptimizelySDKSharediOS.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1188,6 +1189,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 777829E224F9AB001A46FE0E /* Pods-OptimizelySDKSharediOS.rc.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1213,6 +1215,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = EEA436FFCE95FFFF3CAC0BC8 /* Pods-OptimizelySDKSharediOS.beta.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1238,6 +1241,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0DABB0664478DB341DEF3237 /* Pods-OptimizelySDKSharediOS.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1327,6 +1331,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5CF4F1B8D6539A2AE661E1E1 /* Pods-OptimizelySDKSharedTVOS.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1358,6 +1363,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0567D389B36E6BC68E678D64 /* Pods-OptimizelySDKSharedTVOS.rc.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1385,6 +1391,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CC9DFCEBC227A64F4FE43A04 /* Pods-OptimizelySDKSharedTVOS.beta.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
@@ -1412,6 +1419,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 6042179012EFD11109128C34 /* Pods-OptimizelySDKSharedTVOS.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;

--- a/OptimizelySDKTVOS/OptimizelySDKTVOS.xcodeproj/project.pbxproj
+++ b/OptimizelySDKTVOS/OptimizelySDKTVOS.xcodeproj/project.pbxproj
@@ -721,6 +721,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E62FD13CF8241FFB0083F99C /* Pods-OptimizelySDKTVOS.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -810,6 +811,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 876F26E13F09AA5120932B3E /* Pods-OptimizelySDKTVOS.rc.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -899,6 +901,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 28DE410B256E509B248B59A2 /* Pods-OptimizelySDKTVOS.beta.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -988,6 +991,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 642771BAF551A7140B449867 /* Pods-OptimizelySDKTVOS.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;

--- a/OptimizelySDKUniversal/OptimizelySDKUniversal.xcodeproj/project.pbxproj
+++ b/OptimizelySDKUniversal/OptimizelySDKUniversal.xcodeproj/project.pbxproj
@@ -1423,6 +1423,7 @@
 		EA52CA871E851CC100D4FCA0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -1473,6 +1474,7 @@
 		EA52CA881E851CC100D4FCA0 /* Beta */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -1523,6 +1525,7 @@
 		EA52CA891E851CC100D4FCA0 /* RC */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -1573,6 +1576,7 @@
 		EA52CA8A1E851CC100D4FCA0 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -1622,6 +1626,7 @@
 		EA52CB201E851CEE00D4FCA0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
@@ -1672,6 +1677,7 @@
 		EA52CB211E851CEE00D4FCA0 /* Beta */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
@@ -1722,6 +1728,7 @@
 		EA52CB221E851CEE00D4FCA0 /* RC */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";
@@ -1772,6 +1779,7 @@
 		EA52CB231E851CEE00D4FCA0 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "iPhone Developer";

--- a/OptimizelySDKUserProfile/OptimizelySDKUserProfile.xcodeproj/project.pbxproj
+++ b/OptimizelySDKUserProfile/OptimizelySDKUserProfile.xcodeproj/project.pbxproj
@@ -998,6 +998,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7186951DC2D644C1E9A6AFA0 /* Pods-OptimizelySDKUserProfileiOS.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -1022,6 +1023,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = ACD0424A2B0DC653D977B001 /* Pods-OptimizelySDKUserProfileiOS.rc.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -1042,6 +1044,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = DF1A170D408271B194F004A8 /* Pods-OptimizelySDKUserProfileiOS.beta.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -1062,6 +1065,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 44B5FC3E732A6470A867EF0A /* Pods-OptimizelySDKUserProfileiOS.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -1130,6 +1134,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1C62B7FF941C777EC3DEB0F8 /* Pods-OptimizelySDKUserProfileTVOS.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -1157,6 +1162,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 05377D1F51DA2A59E7D6E949 /* Pods-OptimizelySDKUserProfileTVOS.rc.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -1180,6 +1186,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 30FCB99F9980AFF868A10EF5 /* Pods-OptimizelySDKUserProfileTVOS.beta.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;
@@ -1203,6 +1210,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2DA65807C8109484A1CFD535 /* Pods-OptimizelySDKUserProfileTVOS.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEFINES_MODULE = YES;

--- a/OptimizelySDKiOS/OptimizelySDKiOS.xcodeproj/project.pbxproj
+++ b/OptimizelySDKiOS/OptimizelySDKiOS.xcodeproj/project.pbxproj
@@ -715,6 +715,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = CB155056A7C50E7FB412626B /* Pods-OptimizelySDKiOS.beta.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -801,6 +802,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 9CB2521251DA450B31936CD1 /* Pods-OptimizelySDKiOS.release.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -946,6 +948,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BE8953582A06FA8691394A65 /* Pods-OptimizelySDKiOS.debug.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -965,6 +968,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 954B435FB8E68A315C134E1A /* Pods-OptimizelySDKiOS.rc.xcconfig */;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;


### PR DESCRIPTION
OASIS-1614 APPLICATION_EXTENSION_API_ONLY = YES
Changing all objective-c-sdk *.framework "Build Settings" to
APPLICATION_EXTENSION_API_ONLY = YES along with added minor code
changes enables Optimizely objective-c-sdk to be used in iOS and tvOS
app extensions.  SEE: Apple's "App Extension Programming Guide".
Apply APPLICATION_EXTENSION_API_ONLY = YES to all *.framework targets
Localytics-iOS-4.2.0 --> Localytics-iOS-4.3.0