### PR TITLE
Fix red Xcode Project Navigator group folder

### DIFF
--- a/OptimizelySDKUniversal/OptimizelySDKUniversal.xcodeproj/project.pbxproj
+++ b/OptimizelySDKUniversal/OptimizelySDKUniversal.xcodeproj/project.pbxproj
@@ -714,8 +714,7 @@
 				EAC5F1931E7B61C800C087B8 /* Shared */,
 				EAC5F18E1E7B617A00C087B8 /* UserProfile */,
 			);
-			name = OptimizelySDKUniversal;
-			path = OptimizelySDK;
+			path = OptimizelySDKUniversal;
 			sourceTree = "<group>";
 		};
 		EAC5F1871E7B60D700C087B8 /* Core */ = {


### PR DESCRIPTION
Summary: OASIS-2443 [iOS] Fix red Xcode Project Navigator group folder

Test Plan:
* Build OptimizelySDKiOSUniversal target.
"Build Succeeded"
PASSED
* sh ./Scripts/build_all.sh
** BUILD SUCCEEDED **
PASSED
* OptimizelyiOSDemoApp / "iPhone X" simulator
OptimizelyiOSDemoApp[94876:2168671] [OPTIMIZELY SDK][INFO]:[EVENT DISPATCHER] Successfully tracked event sample_conversion for user 285956
PASSED
* Test Suite's
'OptimizelySDKiOSUniversalTests.xctest' passed
'OptimizelySDKCoreiOSTests.xctest' passed
'OptimizelySDKTVOSUniversalTests.xctest' passed
'OptimizelySDKCoreTVOSTests.xctest' passed
PASSED

Subscribers: thomas.zurkan

JIRA Issues: OASIS-2443

Differential Revision: https://phabricator.optimizely.com/D19472