### PR TITLE
OASIS-2442 Remedying Xcode 9.2 compiler warnings in unit tests

### DIFF
--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYBuilderTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYBuilderTest.m
@@ -80,7 +80,7 @@ static NSData *datafile;
 }
 
 - (void)testBuilderCanAssignEventDispatcher {
-    id<OPTLYEventDispatcher> eventDispatcher = [[NSObject alloc] init];
+    id<OPTLYEventDispatcher> eventDispatcher = (id<OPTLYEventDispatcher>)[[NSObject alloc] init];
     
     Optimizely *defaultOptimizely = [Optimizely init:^(OPTLYBuilder *builder) {
         builder.datafile = datafile;
@@ -116,7 +116,10 @@ static NSData *datafile;
 }
 
 - (void)testInitializationWithoutBuilder {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     Optimizely *optimizely = [Optimizely init:nil];
+#pragma clang diagnostic pop
     XCTAssertNil(optimizely);
 }
 

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYErrorHandlerTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYErrorHandlerTest.m
@@ -35,13 +35,16 @@
 
 - (void)testConformsToOPTLYLoggerProtocol
 {
-    id<OPTLYErrorHandler> errorHandler = [NSObject new];
-    BOOL conformsToProtocol = [OPTLYErrorHandler conformsToOPTLYErrorHandlerProtocol:[errorHandler class]];
-    NSAssert(conformsToProtocol == FALSE, @"Object does not conform to protocol.");
-    
-    errorHandler = [OPTLYErrorHandlerDefault new];
-    conformsToProtocol = [OPTLYErrorHandler conformsToOPTLYErrorHandlerProtocol:[errorHandler class]];
-    NSAssert(conformsToProtocol == TRUE, @"Object should conform to protocol.");
+    {
+        NSObject* errorHandler = [NSObject new];
+        BOOL conformsToProtocol = [OPTLYErrorHandler conformsToOPTLYErrorHandlerProtocol:[errorHandler class]];
+        XCTAssert(conformsToProtocol == FALSE, @"Object does not conform to protocol.");
+    }
+    {
+        id<OPTLYErrorHandler> errorHandler = [OPTLYErrorHandlerDefault new];
+        BOOL conformsToProtocol = [OPTLYErrorHandler conformsToOPTLYErrorHandlerProtocol:[errorHandler class]];
+        XCTAssert(conformsToProtocol == TRUE, @"Object should conform to protocol.");
+    }
 }
 
 @end

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYEventDispatcherTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYEventDispatcherTest.m
@@ -35,13 +35,16 @@
 
 - (void)testConformsToOPTLYEventDispatcherProtocol
 {
-    id<OPTLYEventDispatcher> eventDispatcher = [NSObject new];
-    BOOL conformsToProtocol = [OPTLYEventDispatcherUtility conformsToOPTLYEventDispatcherProtocol:[eventDispatcher class]];
-    NSAssert(conformsToProtocol == FALSE, @"Object does not conform to protocol.");
-    
-    eventDispatcher = [OPTLYEventDispatcherNoOp new];
-    conformsToProtocol = [OPTLYEventDispatcherUtility conformsToOPTLYEventDispatcherProtocol:[eventDispatcher class]];
-    NSAssert(conformsToProtocol == TRUE, @"Object should conform to protocol.");
+    {
+        NSObject* eventDispatcher = [NSObject new];
+        BOOL conformsToProtocol = [OPTLYEventDispatcherUtility conformsToOPTLYEventDispatcherProtocol:[eventDispatcher class]];
+        XCTAssert(conformsToProtocol == FALSE, @"Object does not conform to protocol.");
+    }
+    {
+        id<OPTLYEventDispatcher> eventDispatcher = [OPTLYEventDispatcherNoOp new];
+        BOOL conformsToProtocol = [OPTLYEventDispatcherUtility conformsToOPTLYEventDispatcherProtocol:[eventDispatcher class]];
+        XCTAssert(conformsToProtocol == TRUE, @"Object should conform to protocol.");
+    }
 }
 
 @end

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYLoggerTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYLoggerTest.m
@@ -35,13 +35,16 @@
 
 - (void)testConformsToOPTLYLoggerProtocol
 {
-    id<OPTLYLogger> logger = [NSObject new];
-    BOOL conformsToProtocol = [OPTLYLoggerUtility conformsToOPTLYLoggerProtocol:[logger class]];
-    NSAssert(conformsToProtocol == FALSE, @"Object does not conform to protocol.");
-    
-    logger = [OPTLYLoggerDefault new];
-    conformsToProtocol = [OPTLYLoggerUtility conformsToOPTLYLoggerProtocol:[logger class]];
-    NSAssert(conformsToProtocol == TRUE, @"Object should conform to protocol.");
+    {
+        NSObject* logger = [NSObject new];
+        BOOL conformsToProtocol = [OPTLYLoggerUtility conformsToOPTLYLoggerProtocol:[logger class]];
+        XCTAssert(conformsToProtocol == FALSE, @"Object does not conform to protocol.");
+    }
+    {
+        id<OPTLYLogger> logger = [OPTLYLoggerDefault new];
+        BOOL conformsToProtocol = [OPTLYLoggerUtility conformsToOPTLYLoggerProtocol:[logger class]];
+        XCTAssert(conformsToProtocol == TRUE, @"Object should conform to protocol.");
+    }
 }
 
 

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYProjectConfigTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYProjectConfigTest.m
@@ -127,8 +127,8 @@ static NSString * const kInvalidDatafileVersionDatafileName = @"InvalidDatafileV
 - (void)testInitWithBuilderBlockInvalidModulesFails {
     NSData *datafile = [OPTLYTestHelper loadJSONDatafileIntoDataObject:kDataModelDatafileName];
     
-    id<OPTLYLogger> logger = [NSObject new];
-    id<OPTLYErrorHandler> errorHandler = [NSObject new];
+    id<OPTLYLogger> logger = (id<OPTLYLogger>)[NSObject new];
+    id<OPTLYErrorHandler> errorHandler = (id<OPTLYErrorHandler>)[NSObject new];
     
     OPTLYProjectConfig *projectConfig = [OPTLYProjectConfig init:^(OPTLYProjectConfigBuilder * _Nullable builder){
         builder.datafile = datafile;

--- a/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcherTests/OPTLYEventDispatcherTest.m
+++ b/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcherTests/OPTLYEventDispatcherTest.m
@@ -339,7 +339,7 @@ typedef void (^EventDispatchCallback)(NSData * _Nullable data, NSURLResponse * _
     typedef void (^FlushEventsBlock)(void);
     __block __weak FlushEventsBlock weakFlushEvents = nil;
     __weak typeof(self) weakSelf = self;
-    __block void (^flushEvents)() = ^(){
+    __block void (^flushEvents)(void) = ^(){
         FlushEventsBlock strongFlushEvents = weakFlushEvents;
         attempts++;
         [eventDispatcher flushEvents:^{

--- a/OptimizelySDKShared/OptimizelySDKSharedTests/OPTLYManagerTest.m
+++ b/OptimizelySDKShared/OptimizelySDKSharedTests/OPTLYManagerTest.m
@@ -114,7 +114,7 @@ static NSString * const kClientEngine = @"tvos-sdk";
     id partialMockManager = OCMPartialMock(manager);
     
     // mock a failed cached datafile load
-    id partialDatafileManagerMock = OCMPartialMock(manager.datafileManager);
+    id partialDatafileManagerMock = OCMPartialMock((NSObject*)manager.datafileManager);
     OCMStub([partialDatafileManagerMock getSavedDatafile:nil]).andReturn(nil);
     
     OPTLYClient *client = [partialMockManager initialize];
@@ -371,7 +371,10 @@ static NSString * const kClientEngine = @"tvos-sdk";
         builder.projectId = kProjectId;
     }];
     
-    id partialMockManager = OCMPartialMock(manager);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-value"
+    OCMPartialMock(manager);
+#pragma clang diagnostic pop
     
     // setup async expectation
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"testInitializeWithCallbackDownloadErrorNoDatafile"];
@@ -390,13 +393,15 @@ static NSString * const kClientEngine = @"tvos-sdk";
 - (void)isClientValid:(OPTLYClient *)client
              datafile:(NSData *)datafile
 {
-    Optimizely *optly = [Optimizely init:^(OPTLYBuilder * _Nullable builder) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-value"
+    [Optimizely init:^(OPTLYBuilder * _Nullable builder) {
         builder.datafile = datafile;
         builder.clientEngine = kClientEngine;
         builder.clientVersion = kClientVersion;
     }];
-    OPTLYProjectConfig *projectConfig = optly.config;
-    
+#pragma clang diagnostic pop
+
     XCTAssertNotNil(client, @"Client should not be nil.");
     // TODO (Alda): Need to write equality methods for the data models to properly make this assertion
     //XCTAssert([projectConfig isEqual:client.optimizely.config], @"Optimizely config is invalid.");

--- a/OptimizelySDKUserProfileService/OptimizelySDKUserProfileServiceTests/OptimizelySDKUserProfileServiceTests.m
+++ b/OptimizelySDKUserProfileService/OptimizelySDKUserProfileServiceTests/OptimizelySDKUserProfileServiceTests.m
@@ -179,10 +179,10 @@ static NSData *whitelistingDatafile;
     NSDictionary *userProfile1 = [self.userProfileService lookup:kUserId1];
     XCTAssertNil(userProfile1, @"User profile for userId 1 should have been removed.");
     
-    NSString *userProfile2 = [self.userProfileService lookup:kUserId2];
+    NSDictionary *userProfile2 = [self.userProfileService lookup:kUserId2];
     XCTAssertNotNil(userProfile2, @"User profile for userId 2 should not be removed.");
     
-    NSString *userProfile3 = [self.userProfileService lookup:kUserId3];
+    NSDictionary *userProfile3 = [self.userProfileService lookup:kUserId3];
     XCTAssertNotNil(userProfile3, @"User profile for userId 3a should not be removed.");
     
     NSDictionary *userData = [self.userProfileService.dataStore getUserDataForType:OPTLYDataStoreDataTypeUserProfileService];
@@ -196,10 +196,10 @@ static NSData *whitelistingDatafile;
     NSDictionary *userProfile1 = [self.userProfileService lookup:kUserId1];
     XCTAssertNil(userProfile1, @"User profile for userId 1 should have been removed.");
     
-    NSString *userProfile2 = [self.userProfileService lookup:kUserId2];
+    NSDictionary *userProfile2 = [self.userProfileService lookup:kUserId2];
     XCTAssertNil(userProfile2, @"User profile for userId 2 should have been removed.");
     
-    NSString *userProfile3 = [self.userProfileService lookup:kUserId3];
+    NSDictionary *userProfile3 = [self.userProfileService lookup:kUserId3];
     XCTAssertNil(userProfile3, @"User profile for userId 3 should have been removed.");
     
     NSDictionary *userData = [self.userProfileService.dataStore getUserDataForType:OPTLYDataStoreDataTypeUserProfileService];
@@ -279,7 +279,10 @@ static NSData *whitelistingDatafile;
     OPTLYUserProfileServiceDefault *userProfileService = [[OPTLYUserProfileServiceDefault alloc] init];
     [userProfileService removeAllUserExperimentRecords];
     XCTAssertNotNil(userProfileService);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     [userProfileService save:nil];
+#pragma clang diagnostic pop
     XCTAssertEqual(0, [[userProfileService.dataStore getUserDataForType:OPTLYDataStoreDataTypeUserProfileService] count]);
 }
 
@@ -319,7 +322,7 @@ static NSData *whitelistingDatafile;
     [self saveUserId:kUserId3 experimentId:kExperimentId3c variationId:kVariationId3c];
     
     NSDictionary *legacyUserProfileData = [self.userProfileService.dataStore getUserDataForType:OPTLYDataStoreDataTypeUserProfile];
-    XCTAssert([legacyUserProfileData count] == 3, @"Invalid number of legacy user profile entities saved: %@.", [legacyUserProfileData count]);
+    XCTAssert([legacyUserProfileData count] == 3, @"Invalid number of legacy user profile entities saved: %@.", @([legacyUserProfileData count]));
     [self.userProfileService migrateLegacyUserProfileIfNeeded];
     
     NSDictionary *newUserProfileDict1 = [self.userProfileService lookup:kUserId1];


### PR DESCRIPTION
This pull request remedies approximately half the Xcode 9.2 compiler
warnings occurring in objective-c-sdk unit tests.  The P.R. addresses "lint".

There are no new tests, deleted tests, or modification of intent of existing tests.
The pull request changes involve some extra care with type declarations,
type casts, and some added #pragma's to suppress warnings.

There are no changes to SDK framework targets' source code.
