### PR TITLE
Kroach/oasis 2768 upgradev2

### DIFF
--- a/OptimizelySDKCore/OptimizelySDKCore.xcodeproj/project.pbxproj
+++ b/OptimizelySDKCore/OptimizelySDKCore.xcodeproj/project.pbxproj
@@ -198,6 +198,8 @@
 		3ECB82061FD92736006505E6 /* OPTLYRollout.m in Sources */ = {isa = PBXBuildFile; fileRef = 3ECB82031FD92736006505E6 /* OPTLYRollout.m */; };
 		3ECB82071FD92736006505E6 /* OPTLYRollout.m in Sources */ = {isa = PBXBuildFile; fileRef = 3ECB82031FD92736006505E6 /* OPTLYRollout.m */; };
 		3EE687AA1F312FA30084B375 /* BucketerTestsDatafile2.json in Resources */ = {isa = PBXBuildFile; fileRef = 3E92800D1F26AD4700214C58 /* BucketerTestsDatafile2.json */; };
+		3EF9D99020AE425000A9B002 /* V2TestDatafile.json in Resources */ = {isa = PBXBuildFile; fileRef = 3EF9D98F20AE424F00A9B002 /* V2TestDatafile.json */; };
+		3EF9D99120AE425000A9B002 /* V2TestDatafile.json in Resources */ = {isa = PBXBuildFile; fileRef = 3EF9D98F20AE424F00A9B002 /* V2TestDatafile.json */; };
 		4FFB468BAFC670CF55514638 /* Pods_OptimizelySDKCoreTVOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9A3A368275572C29A76DC80A /* Pods_OptimizelySDKCoreTVOSTests.framework */; };
 		5E4C07F31DFF645C0042B1F8 /* InvalidDatafileVersionDatafile.json in Resources */ = {isa = PBXBuildFile; fileRef = 5E4C07F21DFF645C0042B1F8 /* InvalidDatafileVersionDatafile.json */; };
 		5E4C07F41DFF645C0042B1F8 /* InvalidDatafileVersionDatafile.json in Resources */ = {isa = PBXBuildFile; fileRef = 5E4C07F21DFF645C0042B1F8 /* InvalidDatafileVersionDatafile.json */; };
@@ -580,6 +582,7 @@
 		3ECB81FD1FD926FE006505E6 /* OPTLYVariableUsage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OPTLYVariableUsage.m; sourceTree = "<group>"; };
 		3ECB82021FD92736006505E6 /* OPTLYRollout.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OPTLYRollout.h; sourceTree = "<group>"; };
 		3ECB82031FD92736006505E6 /* OPTLYRollout.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OPTLYRollout.m; sourceTree = "<group>"; };
+		3EF9D98F20AE424F00A9B002 /* V2TestDatafile.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = V2TestDatafile.json; sourceTree = "<group>"; };
 		51B050141BF2E9277B39EEE8 /* Pods-OptimizelySDKCoreiOSTests.rc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OptimizelySDKCoreiOSTests.rc.xcconfig"; path = "../Pods/Target Support Files/Pods-OptimizelySDKCoreiOSTests/Pods-OptimizelySDKCoreiOSTests.rc.xcconfig"; sourceTree = "<group>"; };
 		5E4C07F21DFF645C0042B1F8 /* InvalidDatafileVersionDatafile.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = InvalidDatafileVersionDatafile.json; sourceTree = "<group>"; };
 		5E4C07FA1DFF66B00042B1F8 /* OPTLYNetworkServiceTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OPTLYNetworkServiceTest.m; sourceTree = "<group>"; };
@@ -1129,6 +1132,7 @@
 				EA2FAB971DC6FDFA00B1D81B /* test_data_10_experiments.json */,
 				EA2FAB981DC6FDFA00B1D81B /* test_data_25_experiments.json */,
 				EA2FAB991DC6FDFA00B1D81B /* test_data_50_experiments.json */,
+				3EF9D98F20AE424F00A9B002 /* V2TestDatafile.json */,
 			);
 			path = TestData;
 			sourceTree = "<group>";
@@ -1611,6 +1615,7 @@
 				5E4C07F31DFF645C0042B1F8 /* InvalidDatafileVersionDatafile.json in Resources */,
 				3E99CF7F1FE02C2D00B16B97 /* optimizely_6372300739_v4.json in Resources */,
 				EA2FABC91DC6FDFA00B1D81B /* BucketerTestsDatafile.json in Resources */,
+				3EF9D99020AE425000A9B002 /* V2TestDatafile.json in Resources */,
 				EA2FABD21DC6FDFA00B1D81B /* test_data_25_experiments.json in Resources */,
 				3EE687AA1F312FA30084B375 /* BucketerTestsDatafile2.json in Resources */,
 			);
@@ -1634,6 +1639,7 @@
 				EA2FABD01DC6FDFA00B1D81B /* test_data_10_experiments.json in Resources */,
 				3E99CF801FE02C2E00B16B97 /* optimizely_6372300739_v4.json in Resources */,
 				5E4C07F41DFF645C0042B1F8 /* InvalidDatafileVersionDatafile.json in Resources */,
+				3EF9D99120AE425000A9B002 /* V2TestDatafile.json in Resources */,
 				EA2FABCA1DC6FDFA00B1D81B /* BucketerTestsDatafile.json in Resources */,
 				EA2FABD31DC6FDFA00B1D81B /* test_data_25_experiments.json in Resources */,
 			);

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
@@ -262,7 +262,7 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
     params[OPTLYEventParameterKeysClientEngine] = [OPTLYEventBuilderDefault stringOrEmpty:[config clientEngine]];
     params[OPTLYEventParameterKeysClientVersion] = [OPTLYEventBuilderDefault stringOrEmpty:[config clientVersion]];
     params[OPTLYEventParameterKeysRevision] = [OPTLYEventBuilderDefault stringOrEmpty:config.revision];
-    params[OPTLYEventParameterKeysAnonymizeIP] = config.anonymizeIP ? @YES : @NO;
+    params[OPTLYEventParameterKeysAnonymizeIP] = @(config.anonymizeIP.boolValue);
     
     return [params copy];
 }

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYProjectConfig.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYProjectConfig.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_END
 /// Datafile Revision number
 @property (nonatomic, strong, nonnull) NSString *revision;
 /// Flag for IP anonymization
-@property (nonatomic, assign) BOOL anonymizeIP;
+@property (nonatomic) NSNumber<Optional> *anonymizeIP;
 /// List of Optimizely Experiment objects
 @property (nonatomic, strong, nonnull) NSArray<OPTLYExperiment> *experiments;
 /// List of Optimizely Event Type objects

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYProjectConfig.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYProjectConfig.m
@@ -113,6 +113,12 @@ NSString * const kExpectedDatafileVersion  = @"4";
             [builder.logger logMessage:logMessage withLevel:OptimizelyLogLevelWarning];
         }
         
+        if (projectConfig.anonymizeIP == nil) {
+            NSString *logMessage = @"Forcing old datafile to include anonymizeIP required by V4 format.";
+            [builder.logger logMessage:logMessage withLevel:OptimizelyLogLevelWarning];
+            projectConfig.anonymizeIP = @1;
+        }
+
         if (datafileError)
         {
             NSError *error = [NSError errorWithDomain:OPTLYErrorHandlerMessagesDomain

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYProjectConfigTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYProjectConfigTest.m
@@ -153,7 +153,7 @@ static NSString * const kInvalidDatafileVersionDatafileName = @"InvalidDatafileV
     NSData *datafile = [OPTLYTestHelper loadJSONDatafileIntoDataObject:kDatafileNameAnonymizeIPFalse];
     OPTLYProjectConfig *projectConfig = [[OPTLYProjectConfig alloc] initWithDatafile:datafile];
     
-    XCTAssertFalse(projectConfig.anonymizeIP, @"IP anonymization should be set to false.");
+    XCTAssertFalse(projectConfig.anonymizeIP.boolValue, @"IP anonymization should be set to false.");
 }
 
 #pragma mark - Test getExperimentForKey:
@@ -467,7 +467,7 @@ static NSString * const kInvalidDatafileVersionDatafileName = @"InvalidDatafileV
     NSAssert([projectConfig.revision isEqualToString:kRevision], @"Invalid revision number.");
     
     // validate IP anonymization value
-    XCTAssertTrue(projectConfig.anonymizeIP, @"IP anonymization should be set to true.");
+    XCTAssertTrue(projectConfig.anonymizeIP.boolValue, @"IP anonymization should be set to true.");
     
     // check experiments
     NSAssert([projectConfig.experiments count] == kNumberOfExperimentObjects, @"deserializeJSONArray failed to deserialize the right number of experiments objects in project config.");

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
@@ -37,6 +37,7 @@ static NSString *const kExperimentKey = @"testExperimentWithFirefoxAudience";
 static NSString *const kEventNameWithMultipleExperiments = @"testEventWithMultipleExperiments";
 
 // datafiles
+static NSString *const kV2TestDatafileName = @"V2TestDatafile";
 static NSString *const kBucketerTestDatafileName = @"BucketerTestsDatafile";
 
 // user IDs
@@ -155,6 +156,15 @@ static NSString * const kVariationIDForWhitelisting = @"variation4";
                                     userId:kUserId
                                 attributes:attributesWithUserInAudience];
     XCTAssertNotNil(variation);
+}
+
+// Test initializing with older V2 datafile
+- (void)testOlderV2Datafile {
+    NSData *datafile = [OPTLYTestHelper loadJSONDatafileIntoDataObject:kV2TestDatafileName];
+    Optimizely *optimizely = [Optimizely init:^(OPTLYBuilder * _Nullable builder) {
+        builder.datafile = datafile;
+    }];
+    XCTAssertNotNil(optimizely);
 }
 
 // Test whitelisting works with get variation

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/TestData/V2TestDatafile.json
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/TestData/V2TestDatafile.json
@@ -1,0 +1,48 @@
+{
+    "accountId": "12345",
+    "projectId": "23456",
+    "revision": "6",
+    "version": "2",
+    "experiments": [
+        {
+            "key": "my_experiment",
+            "id": "45678",
+            "layerId": "34567",
+            "status": "Running",
+            "variations": [
+                {
+                    "id": "56789",
+                    "key": "control"
+                },
+                {
+                    "id": "67890",
+                    "key": "treatment"
+                }
+            ],
+            "trafficAllocation": [
+                {
+                    "entityId": "56789",
+                    "endOfRange": 5000
+                },
+                {
+                    "entityId": "67890",
+                    "endOfRange": 10000
+                }
+            ],
+            "audienceIds": [],
+            "forcedVariations": {}
+        }
+    ],
+    "events": [
+        {
+            "experimentIds": [
+                "34567"
+            ],
+            "id": "56789",
+            "key": "my_conversion"
+        }
+    ],
+    "audiences": [],
+    "attributes": [],
+    "groups": []
+}


### PR DESCRIPTION
Changes added to OPTLYProjectConfig.m+.h to retroactively add some
support for V2 datafiles.  Add anonomizeIP : true to V2 datafiles that are
missing anonomizeIP key-value pairs.

TEST:
* sh ./Scripts/build_all.sh PASSED
* 8+1 iOS test suites PASSED
* 7+1 tvOS test suites PASSED
* OptimizelyiOSDemoApp Build / Clean / Run/ exercise PASSED
