### PR TITLE
Clarifying ownership of SDK in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![Platforms](https://img.shields.io/cocoapods/p/OptimizelySDKTVOS.svg)
 [![Podspec](https://img.shields.io/cocoapods/v/OptimizelySDKTVOS.svg)](https://cocoapods.org/pods/OptimizelySDKTVOS)
 
-This repository houses the Optimizely Mobile and OTT experimentation SDKs.
+This repository houses the official Optimizely Mobile and OTT experimentation SDKs.
 
 
 ## Getting Started


### PR DESCRIPTION
Due to there being several third-party SDKs in different languages of varying quality / age, adding "official" to the phrasing of the title should help people understand that this is owned and maintained by Optimizely.