### PR TITLE
Add Release 1.5.2 message to master CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Optimizely Objective-C SDK Changelog
+## 1.5.2
+June 15, 2018
+
+### New Features
+* Updated SDK targets to Xcode 9.4 recommended settings, pod update'd third party Cocoapods used by the 2 demo apps,
+and eliminated Xcode 9.4 Build and Analyze warnings for SDK targets.
+
 ## 2.0.2-beta1
 May 17, 2018
 


### PR DESCRIPTION
The pull requests synchs Release 1.5.2 message onto master branch's
copy of CHANGELOG.md .  Our objective-c-sdk 1.5.2 was released
last week, June 15, 2018 .
