### PR TITLE
fix(track): Send decisions for all experiments using an event when using track

### DIFF
--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
@@ -321,6 +321,9 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
     }
     
     NSMutableArray *conversionEventParams = [NSMutableArray new];
+    NSMutableDictionary *params = [NSMutableDictionary new];
+    NSMutableArray *decisions = [NSMutableArray new];
+    
     for (NSString *eventExperimentId in eventExperimentIds) {
         OPTLYExperiment *experiment = [config getExperimentForId:eventExperimentId];
         
@@ -338,63 +341,60 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
                                                                      bucketer:bucketer];
         
         if (bucketedVariation) {
-            
-            NSMutableDictionary *params = [NSMutableDictionary new];
-            
             NSMutableDictionary *decision = [NSMutableDictionary new];
             decision[OPTLYEventParameterKeysDecisionCampaignId]         =[OPTLYEventBuilderDefault stringOrEmpty:experiment.layerId];
             decision[OPTLYEventParameterKeysDecisionExperimentId]       =experiment.experimentId;
             decision[OPTLYEventParameterKeysDecisionVariationId]        =bucketedVariation.variationId;
             decision[OPTLYEventParameterKeysDecisionIsLayerHoldback]    = @NO;
-            NSArray *decisions = @[decision];
-            
-            NSMutableDictionary *event = [NSMutableDictionary new];
-            event[OPTLYEventParameterKeysEntityId]      =[OPTLYEventBuilderDefault stringOrEmpty:eventEntity.eventId];
-            event[OPTLYEventParameterKeysTimestamp]     =[self time] ? : @0;
-            event[OPTLYEventParameterKeysKey]           =eventKey;
-            event[OPTLYEventParameterKeysUUID]          =[[NSUUID UUID] UUIDString];
-            
-            NSMutableDictionary *mutableEventTags = [[NSMutableDictionary alloc] initWithDictionary:eventTags];
-            
-            for (NSString *key in [eventTags allKeys]) {
-                id eventTagValue = eventTags[key];
-                
-                // only string, long, int, double, float, and booleans are supported
-                if ([eventTagValue isKindOfClass:[NSString class]] || [eventTagValue isKindOfClass:[NSNumber class]]) {
-                    if ([key isEqualToString:OPTLYEventMetricNameRevenue]) {
-                        // Allow only 'revenue' eventTags with integer values (max long long); otherwise the value will be cast to an integer
-                        NSNumber *revenueValue = [self revenueValue:config value:eventTags[OPTLYEventMetricNameRevenue]];
-                        if (revenueValue != nil) {
-                            event[OPTLYEventMetricNameRevenue] = revenueValue;
-                        } else {
-                            [mutableEventTags removeObjectForKey:OPTLYEventMetricNameRevenue];
-                        }
-                    }
-                    if ([key isEqualToString:OPTLYEventMetricNameValue]) {
-                        // Allow only 'value' eventTags with double values; otherwise the value will be cast to a double
-                        NSNumber *numericValue = [self numericValue:config value:eventTags[OPTLYEventMetricNameValue]];
-                        if (numericValue != nil) {
-                            event[OPTLYEventMetricNameValue] = numericValue;
-                        } else {
-                            [mutableEventTags removeObjectForKey:OPTLYEventMetricNameValue];
-                        }
-                    }
-                } else {
-                    [mutableEventTags removeObjectForKey:key];
-                    NSString *logMessage = [NSString stringWithFormat:OPTLYLoggerMessagesEventTagValueInvalid, key];
-                    [config.logger logMessage:logMessage withLevel:OptimizelyLogLevelDebug];
-                }
-            }
-            event[OPTLYEventParameterKeysTags] = mutableEventTags;
-
-            NSArray *events = @[event];
-            
-            params[OPTLYEventParameterKeysDecisions] = decisions;
-            params[OPTLYEventParameterKeysEvents] = events;
-            
-            [conversionEventParams addObject:params];
+            [decisions addObject:decision];
         }
     }
+
+    NSMutableDictionary *event = [NSMutableDictionary new];
+    event[OPTLYEventParameterKeysEntityId]      =[OPTLYEventBuilderDefault stringOrEmpty:eventEntity.eventId];
+    event[OPTLYEventParameterKeysTimestamp]     =[self time] ? : @0;
+    event[OPTLYEventParameterKeysKey]           =eventKey;
+    event[OPTLYEventParameterKeysUUID]          =[[NSUUID UUID] UUIDString];
+    
+    NSMutableDictionary *mutableEventTags = [[NSMutableDictionary alloc] initWithDictionary:eventTags];
+    
+    for (NSString *key in [eventTags allKeys]) {
+        id eventTagValue = eventTags[key];
+        
+        // only string, long, int, double, float, and booleans are supported
+        if ([eventTagValue isKindOfClass:[NSString class]] || [eventTagValue isKindOfClass:[NSNumber class]]) {
+            if ([key isEqualToString:OPTLYEventMetricNameRevenue]) {
+                // Allow only 'revenue' eventTags with integer values (max long long); otherwise the value will be cast to an integer
+                NSNumber *revenueValue = [self revenueValue:config value:eventTags[OPTLYEventMetricNameRevenue]];
+                if (revenueValue != nil) {
+                    event[OPTLYEventMetricNameRevenue] = revenueValue;
+                } else {
+                    [mutableEventTags removeObjectForKey:OPTLYEventMetricNameRevenue];
+                }
+            }
+            if ([key isEqualToString:OPTLYEventMetricNameValue]) {
+                // Allow only 'value' eventTags with double values; otherwise the value will be cast to a double
+                NSNumber *numericValue = [self numericValue:config value:eventTags[OPTLYEventMetricNameValue]];
+                if (numericValue != nil) {
+                    event[OPTLYEventMetricNameValue] = numericValue;
+                } else {
+                    [mutableEventTags removeObjectForKey:OPTLYEventMetricNameValue];
+                }
+            }
+        } else {
+            [mutableEventTags removeObjectForKey:key];
+            NSString *logMessage = [NSString stringWithFormat:OPTLYLoggerMessagesEventTagValueInvalid, key];
+            [config.logger logMessage:logMessage withLevel:OptimizelyLogLevelDebug];
+        }
+    }
+    event[OPTLYEventParameterKeysTags] = mutableEventTags;
+    
+    NSArray *events = @[event];
+    
+    params[OPTLYEventParameterKeysDecisions] = decisions;
+    params[OPTLYEventParameterKeysEvents] = events;
+    
+    [conversionEventParams addObject:params];
     
     return [conversionEventParams copy];
 }

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
@@ -366,8 +366,6 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
                 NSNumber *revenueValue = [self revenueValue:config value:eventTags[OPTLYEventMetricNameRevenue]];
                 if (revenueValue != nil) {
                     eventDict[OPTLYEventMetricNameRevenue] = revenueValue;
-                } else {
-                    [mutableEventTags removeObjectForKey:OPTLYEventMetricNameRevenue];
                 }
             }
             if ([key isEqualToString:OPTLYEventMetricNameValue]) {
@@ -375,8 +373,6 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
                 NSNumber *numericValue = [self numericValue:config value:eventTags[OPTLYEventMetricNameValue]];
                 if (numericValue != nil) {
                     eventDict[OPTLYEventMetricNameValue] = numericValue;
-                } else {
-                    [mutableEventTags removeObjectForKey:OPTLYEventMetricNameValue];
                 }
             }
         } else {

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
@@ -275,7 +275,6 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
     decision[OPTLYEventParameterKeysDecisionCampaignId]                 =[OPTLYEventBuilderDefault stringOrEmpty:experiment.layerId];
     decision[OPTLYEventParameterKeysDecisionExperimentId]       =experiment.experimentId;
     decision[OPTLYEventParameterKeysDecisionVariationId]        =variationId;
-    decision[OPTLYEventParameterKeysDecisionIsLayerHoldback]    = @NO;
     NSArray *decisions = @[decision];
     
     NSMutableDictionary *event = [NSMutableDictionary new];
@@ -321,7 +320,7 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
     }
     
     NSMutableArray *conversionEventParams = [NSMutableArray new];
-    NSMutableDictionary *params = [NSMutableDictionary new];
+    NSMutableDictionary *snapshot = [NSMutableDictionary new];
     NSMutableArray *decisions = [NSMutableArray new];
     
     for (NSString *eventExperimentId in eventExperimentIds) {
@@ -345,16 +344,15 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
             decision[OPTLYEventParameterKeysDecisionCampaignId]         =[OPTLYEventBuilderDefault stringOrEmpty:experiment.layerId];
             decision[OPTLYEventParameterKeysDecisionExperimentId]       =experiment.experimentId;
             decision[OPTLYEventParameterKeysDecisionVariationId]        =bucketedVariation.variationId;
-            decision[OPTLYEventParameterKeysDecisionIsLayerHoldback]    = @NO;
             [decisions addObject:decision];
         }
     }
 
-    NSMutableDictionary *event = [NSMutableDictionary new];
-    event[OPTLYEventParameterKeysEntityId]      =[OPTLYEventBuilderDefault stringOrEmpty:eventEntity.eventId];
-    event[OPTLYEventParameterKeysTimestamp]     =[self time] ? : @0;
-    event[OPTLYEventParameterKeysKey]           =eventKey;
-    event[OPTLYEventParameterKeysUUID]          =[[NSUUID UUID] UUIDString];
+    NSMutableDictionary *eventDict = [NSMutableDictionary new];
+    eventDict[OPTLYEventParameterKeysEntityId]      =[OPTLYEventBuilderDefault stringOrEmpty:eventEntity.eventId];
+    eventDict[OPTLYEventParameterKeysTimestamp]     =[self time] ? : @0;
+    eventDict[OPTLYEventParameterKeysKey]           =eventKey;
+    eventDict[OPTLYEventParameterKeysUUID]          =[[NSUUID UUID] UUIDString];
     
     NSMutableDictionary *mutableEventTags = [[NSMutableDictionary alloc] initWithDictionary:eventTags];
     
@@ -367,7 +365,7 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
                 // Allow only 'revenue' eventTags with integer values (max long long); otherwise the value will be cast to an integer
                 NSNumber *revenueValue = [self revenueValue:config value:eventTags[OPTLYEventMetricNameRevenue]];
                 if (revenueValue != nil) {
-                    event[OPTLYEventMetricNameRevenue] = revenueValue;
+                    eventDict[OPTLYEventMetricNameRevenue] = revenueValue;
                 } else {
                     [mutableEventTags removeObjectForKey:OPTLYEventMetricNameRevenue];
                 }
@@ -376,7 +374,7 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
                 // Allow only 'value' eventTags with double values; otherwise the value will be cast to a double
                 NSNumber *numericValue = [self numericValue:config value:eventTags[OPTLYEventMetricNameValue]];
                 if (numericValue != nil) {
-                    event[OPTLYEventMetricNameValue] = numericValue;
+                    eventDict[OPTLYEventMetricNameValue] = numericValue;
                 } else {
                     [mutableEventTags removeObjectForKey:OPTLYEventMetricNameValue];
                 }
@@ -387,18 +385,19 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
             [config.logger logMessage:logMessage withLevel:OptimizelyLogLevelDebug];
         }
     }
-    event[OPTLYEventParameterKeysTags] = mutableEventTags;
+    if (mutableEventTags.count > 0) {
+        eventDict[OPTLYEventParameterKeysTags] = mutableEventTags;
+    }
     
-    NSArray *events = @[event];
+    NSArray *events = @[eventDict];
     
-    params[OPTLYEventParameterKeysDecisions] = decisions;
-    params[OPTLYEventParameterKeysEvents] = events;
+    snapshot[OPTLYEventParameterKeysDecisions] = decisions;
+    snapshot[OPTLYEventParameterKeysEvents] = events;
     
-    [conversionEventParams addObject:params];
+    [conversionEventParams addObject:snapshot];
     
     return [conversionEventParams copy];
 }
-
 
 - (NSArray *)createUserFeatures:(OPTLYProjectConfig *)config
                      attributes:(NSDictionary *)attributes {

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventParameterKeys.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventParameterKeys.h
@@ -48,7 +48,6 @@ extern NSString * const OPTLYEventParameterKeysFeaturesName;
 extern NSString * const OPTLYEventParameterKeysDecisionCampaignId;
 extern NSString * const OPTLYEventParameterKeysDecisionExperimentId;
 extern NSString * const OPTLYEventParameterKeysDecisionVariationId;
-extern NSString * const OPTLYEventParameterKeysDecisionIsLayerHoldback;
 
 // --- Common Event Parameters ----
 extern NSString * const OPTLYEventParameterKeysTimestamp;

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventParameterKeys.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventParameterKeys.m
@@ -46,7 +46,6 @@ NSString * const OPTLYEventParameterKeysFeaturesName                    = @"name
 NSString * const OPTLYEventParameterKeysDecisionCampaignId              = @"campaign_id";       // nonnull
 NSString * const OPTLYEventParameterKeysDecisionExperimentId            = @"experiment_id";     // nonnull
 NSString * const OPTLYEventParameterKeysDecisionVariationId             = @"variation_id";      // nonnull
-NSString * const OPTLYEventParameterKeysDecisionIsLayerHoldback         = @"is_campaign_holdback";
 
 // --- Common Event Parameters ----
 NSString * const OPTLYEventParameterKeysTimestamp                       = @"timestamp";         // nonnull

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYEventBuilderTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYEventBuilderTest.m
@@ -1119,8 +1119,6 @@ typedef enum : NSUInteger {
     XCTAssert([campaignId isEqualToString:params[OPTLYEventParameterKeysDecisionCampaignId]], @"Invalid campaignId.");
     XCTAssert([experimentId isEqualToString:params[OPTLYEventParameterKeysDecisionExperimentId]], @"Invalid experimentId.");
     XCTAssert([variationId isEqualToString: params[OPTLYEventParameterKeysDecisionVariationId]], @"Invalid variationId.");
-    NSNumber *isLayerHoldback = params[OPTLYEventParameterKeysDecisionIsLayerHoldback];
-    XCTAssert([isLayerHoldback boolValue] == false, @"Invalid isLayerHoldback value.");
 }
 
 - (void)checkImpression:(NSDictionary *)params

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYEventBuilderTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYEventBuilderTest.m
@@ -72,6 +72,10 @@ static NSString * const kEventWithoutExperimentId = @"6386521015";
 static NSString * const kEventWithMultipleExperimentsName = @"testEventWithMultipleExperiments";
 static NSString * const kEventWithMultipleExperimentsId = @"6372952486";
 
+// events with invalid experiments
+static NSString * const kEventWithInvalidExperimentName = @"testEventWithInvalidExperiment";
+static NSString * const kEventWithInvalidExperimentId = @"6370392433";
+
 typedef enum : NSUInteger {
     ImpressionTicket,
     ConversionTicket
@@ -170,7 +174,12 @@ typedef enum : NSUInteger {
                                                           eventName:kEventWithAudienceName
                                                           eventTags:nil
                                                          attributes:attributes];
-    XCTAssertNil(conversionTicket, @"Conversion ticket should be nil.");
+    
+    XCTAssertNotNil(conversionTicket, @"Conversion ticket should not be nil.");
+    NSDictionary *visitor = conversionTicket[OPTLYEventParameterKeysVisitors][0];
+    NSDictionary *snapshot = visitor[OPTLYEventParameterKeysSnapshots][0];
+    NSArray *decisions = snapshot[OPTLYEventParameterKeysDecisions];
+    XCTAssertEqual([decisions count], 0, @"Conversion ticket should not have any decision");
 }
 
 - (void)testBuildConversionTicketWithExperimentNotRunning
@@ -181,7 +190,28 @@ typedef enum : NSUInteger {
                                                           eventName:kEventWithExperimentNotRunningName
                                                           eventTags:nil
                                                          attributes:nil];
-    XCTAssertNil(conversionTicket, @"Conversion ticket should be nil.");
+    
+    XCTAssertNotNil(conversionTicket, @"Conversion ticket should not be nil.");
+    NSDictionary *visitor = conversionTicket[OPTLYEventParameterKeysVisitors][0];
+    NSDictionary *snapshot = visitor[OPTLYEventParameterKeysSnapshots][0];
+    NSArray *decisions = snapshot[OPTLYEventParameterKeysDecisions];
+    XCTAssertEqual([decisions count], 0, @"Conversion ticket should not have any decision");
+}
+
+- (void)testBuildConversionTicketWithInvalidExperiment
+{
+    NSDictionary *conversionTicket = [self.eventBuilder buildConversionTicket:self.config
+                                                                     bucketer:self.bucketer
+                                                                       userId:kUserId
+                                                                    eventName:kEventWithInvalidExperimentName
+                                                                    eventTags:nil
+                                                                   attributes:nil];
+    
+    XCTAssertNotNil(conversionTicket, @"Conversion ticket should not be nil.");
+    NSDictionary *visitor = conversionTicket[OPTLYEventParameterKeysVisitors][0];
+    NSDictionary *snapshot = visitor[OPTLYEventParameterKeysSnapshots][0];
+    NSArray *decisions = snapshot[OPTLYEventParameterKeysDecisions];
+    XCTAssertEqual([decisions count], 0, @"Conversion ticket should not have any decision");
 }
 
 - (void)testBuildConversionTicketWithoutExperiment

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYEventBuilderTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYEventBuilderTest.m
@@ -138,7 +138,8 @@ typedef enum : NSUInteger {
           variationId:nil
            attributes:self.reservedAttributes
              eventKey:kEventWithoutAudienceName
-            eventTags:nil bucketer:self.bucketer userId:kUserId];
+            eventTags:nil tags:nil
+             bucketer:self.bucketer userId:kUserId];
 }
 
 - (void)testBuildConversionTicketWithValidAudience
@@ -158,7 +159,8 @@ typedef enum : NSUInteger {
           variationId:nil
            attributes:self.attributes
              eventKey:kEventWithAudienceName
-            eventTags:nil bucketer:self.bucketer userId:kUserId];
+            eventTags:nil tags:nil
+             bucketer:self.bucketer userId:kUserId];
 }
 
 #pragma mark - Test buildConversionTicket:... Invalid Args
@@ -436,8 +438,8 @@ typedef enum : NSUInteger {
 
 - (void)testRevenueMetric
 {
-    [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameRevenue:@(kEventRevenue)}
-                       sentEventTags:@{OPTLYEventMetricNameRevenue:@(kEventRevenue)}];
+    NSDictionary *tags = @{OPTLYEventMetricNameRevenue:@(kEventRevenue)};
+    [self commonBuildConversionTicketTest:tags sentEventTags:tags sentTags:tags];
 }
 
 - (void)testRevenueMetricWithDouble
@@ -445,7 +447,8 @@ typedef enum : NSUInteger {
     // The SDK issues a console warning about casting double to "long long",
     // but a "revenue" key-value pair will appear in the transmitted event.
     [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameRevenue:@(888.88)}
-                       sentEventTags:@{OPTLYEventMetricNameRevenue:@(888LL)}];
+                            sentEventTags:@{OPTLYEventMetricNameRevenue:@(888LL)}
+                                 sentTags:@{OPTLYEventMetricNameRevenue:@(888.88)}];
 }
 
 - (void)testRevenueMetricWithHugeDouble
@@ -453,8 +456,8 @@ typedef enum : NSUInteger {
     // The SDK prevents double's outside the range [LLONG_MIN, LLONG_MAX]
     // from being cast into nonsense and sent.  Instead a console warning
     // is issued and the 'revenue' key-value pair will not appear in the transmitted event.
-    [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameRevenue:@(1.0e100)}
-                       sentEventTags:@{}];
+    NSDictionary *tags = @{OPTLYEventMetricNameRevenue:@(1.0e100)};
+    [self commonBuildConversionTicketTest:tags sentEventTags:@{} sentTags:tags];
 }
 
 - (void)testRevenueMetricWithBoundaryDouble1
@@ -469,7 +472,8 @@ typedef enum : NSUInteger {
     double doubleRevenue = stayInside*(double)LLONG_MIN;
     long long longLongRevenue = (long long)doubleRevenue;
     [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameRevenue:@(doubleRevenue)}
-                       sentEventTags:@{OPTLYEventMetricNameRevenue:@(longLongRevenue)}];
+                            sentEventTags:@{OPTLYEventMetricNameRevenue:@(longLongRevenue)}
+                                 sentTags:@{OPTLYEventMetricNameRevenue:@(doubleRevenue)}];
 }
 
 - (void)testRevenueMetricWithBoundaryDouble2
@@ -485,7 +489,8 @@ typedef enum : NSUInteger {
     double doubleRevenue = stayInside*(double)LLONG_MAX;
     long long longLongRevenue = (long long)doubleRevenue;
     [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameRevenue:@(doubleRevenue)}
-                       sentEventTags:@{OPTLYEventMetricNameRevenue:@(longLongRevenue)}];
+                            sentEventTags:@{OPTLYEventMetricNameRevenue:@(longLongRevenue)}
+                                 sentTags:@{OPTLYEventMetricNameRevenue:@(doubleRevenue)}];
 }
 
 - (void)testRevenueMetricWithBoundaryDouble3
@@ -499,7 +504,8 @@ typedef enum : NSUInteger {
     const double stayOutside = 1.00001;
     double doubleRevenue = stayOutside*(double)LLONG_MIN;
     [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameRevenue:@(doubleRevenue)}
-                       sentEventTags:@{}];
+                            sentEventTags:@{}
+                                 sentTags:@{OPTLYEventMetricNameRevenue:@(doubleRevenue)}];
 }
 
 - (void)testRevenueMetricWithBoundaryDouble4
@@ -514,14 +520,16 @@ typedef enum : NSUInteger {
     const double stayOutside = 1.00001;
     double doubleRevenue = stayOutside*(double)LLONG_MAX;
     [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameRevenue:@(doubleRevenue)}
-                       sentEventTags:@{}];
+                            sentEventTags:@{}
+                                 sentTags:@{OPTLYEventMetricNameRevenue:@(doubleRevenue)}];
 }
 
 - (void)testRevenueMetricWithCastUnsignedLongLong
 {
     // "unsigned long long" which is barely in range.
     [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameRevenue:@((unsigned long long)LLONG_MAX)}
-                       sentEventTags:@{OPTLYEventMetricNameRevenue:@(LLONG_MAX)}];
+                            sentEventTags:@{OPTLYEventMetricNameRevenue:@(LLONG_MAX)}
+                                 sentTags:@{OPTLYEventMetricNameRevenue:@((unsigned long long)LLONG_MAX)}];
 }
 
 - (void)testRevenueMetricWithBoundaryUnsignedLongLong
@@ -531,7 +539,8 @@ typedef enum : NSUInteger {
     // is issued and the 'revenue' key-value pair will not appear in the transmitted event.
     // A Bridge Too Far
     [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameRevenue:@(1ULL+(unsigned long long)LLONG_MAX)}
-                       sentEventTags:@{}];
+                            sentEventTags:@{}
+                                 sentTags:@{OPTLYEventMetricNameRevenue:@(1ULL+(unsigned long long)LLONG_MAX)}];
 }
 
 - (void)testRevenueMetricWithHugeUnsignedLongLong
@@ -541,19 +550,20 @@ typedef enum : NSUInteger {
     // is issued and the 'revenue' key-value pair will not appear in the transmitted event.
     // NOTE: ULLONG_MAX > LLONG_MAX is such an example.
     [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameRevenue:@(ULLONG_MAX)}
-                       sentEventTags:@{}];
+                            sentEventTags:@{}
+                                 sentTags:@{OPTLYEventMetricNameRevenue:@(ULLONG_MAX)}];
 }
 
 - (void)testRevenueMetricWithLongLongMax
 {
-    [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameRevenue:@(LLONG_MAX)}
-                       sentEventTags:@{OPTLYEventMetricNameRevenue:@(LLONG_MAX)}];
+    NSDictionary *tags = @{OPTLYEventMetricNameRevenue:@(LLONG_MAX)};
+    [self commonBuildConversionTicketTest:tags sentEventTags:tags sentTags:tags];
 }
 
 - (void)testRevenueMetricWithLongLongMin
 {
-    [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameRevenue:@(LLONG_MIN)}
-                       sentEventTags:@{OPTLYEventMetricNameRevenue:@(LLONG_MIN)}];
+    NSDictionary *tags = @{OPTLYEventMetricNameRevenue:@(LLONG_MIN)};
+    [self commonBuildConversionTicketTest:tags sentEventTags:tags sentTags:tags];
 }
 
 - (void)testRevenueMetricWithBoolean
@@ -562,7 +572,8 @@ typedef enum : NSUInteger {
     // @YES won't be sent to Optimizely server, since it will serialize
     // as "true" instead of a JSON number.
     [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameRevenue:@YES}
-                       sentEventTags:@{}];
+                            sentEventTags:@{}
+                                 sentTags:@{OPTLYEventMetricNameRevenue:@YES}];
 }
 
 - (void)testRevenueMetricWithString
@@ -570,21 +581,23 @@ typedef enum : NSUInteger {
     // The SDK issues a console warning about casting NSString to "long long",
     // but a "revenue" key-value pair will appear in the transmitted event.
     [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameRevenue:@"8.234"}
-                       sentEventTags:@{OPTLYEventMetricNameRevenue:@(8LL)}];
+                            sentEventTags:@{OPTLYEventMetricNameRevenue:@(8LL)}
+                                 sentTags:@{OPTLYEventMetricNameRevenue:@"8.234"}];
 }
 
 - (void)testRevenueMetricWithInvalidObject
 {
     [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameRevenue:@[@"BAD",@"DATA"]}
-                       sentEventTags:@{}];
+                            sentEventTags:nil
+                                 sentTags:nil];
 }
 
 #pragma mark - Test value Metric
 
 - (void)testValueMetric
 {
-    [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameValue:@(kEventValue)}
-                       sentEventTags:@{OPTLYEventMetricNameValue:@(kEventValue)}];
+    NSDictionary *tags = @{OPTLYEventMetricNameValue:@(kEventValue)};
+    [self commonBuildConversionTicketTest:tags sentEventTags:tags sentTags:tags];
 }
 
 - (void)testValueMetricWithBoolean
@@ -593,7 +606,8 @@ typedef enum : NSUInteger {
     // @YES won't be sent to Optimizely server, since it will serialize
     // as "true" instead of a JSON number.
     [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameValue:@YES}
-                       sentEventTags:@{}];
+                            sentEventTags:@{}
+                                 sentTags:@{OPTLYEventMetricNameValue:@YES}];
 }
 
 - (void)testValueMetricWithString
@@ -601,9 +615,11 @@ typedef enum : NSUInteger {
     // The SDK issues a console warning about casting NSString to "double",
     // but a "value" key-value pair will appear in the transmitted event.
     [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameValue:[NSString stringWithFormat:@"%g", kEventValue],
-                                       kAttributeKeyBrowserType:kAttributeValueChrome}
-                       sentEventTags:@{OPTLYEventMetricNameValue:@(kEventValue),
-                                       kAttributeKeyBrowserType:kAttributeValueChrome}];
+                                            kAttributeKeyBrowserType:kAttributeValueChrome}
+                            sentEventTags:@{OPTLYEventMetricNameValue:@(kEventValue),
+                                            kAttributeKeyBrowserType:kAttributeValueChrome}
+                                 sentTags:@{OPTLYEventMetricNameValue:[NSString stringWithFormat:@"%g", kEventValue],
+                                            kAttributeKeyBrowserType:kAttributeValueChrome}];
 }
 
 - (void)testValueMetricWithNAN
@@ -613,8 +629,10 @@ typedef enum : NSUInteger {
     // and omits the proposed "value" key-value pair which will not
     // appear in the transmitted event.  IOW, invalid value suppressed.
     [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameValue:@(NAN),
-                                       kAttributeKeyBrowserType:kAttributeValueChrome}
-                       sentEventTags:@{kAttributeKeyBrowserType:kAttributeValueChrome}];
+                                            kAttributeKeyBrowserType:kAttributeValueChrome}
+                            sentEventTags:@{kAttributeKeyBrowserType:kAttributeValueChrome}
+                                 sentTags:@{OPTLYEventMetricNameValue:@(NAN),
+                                            kAttributeKeyBrowserType:kAttributeValueChrome}];
 }
 
 - (void)testValueMetricWithINFINITY
@@ -624,15 +642,18 @@ typedef enum : NSUInteger {
     // and omits the proposed "value" key-value pair which will not
     // appear in the transmitted event.  IOW, invalid value suppressed.
     [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameValue:@(INFINITY),
-                                       kAttributeKeyBrowserType:kAttributeValueChrome}
-                       sentEventTags:@{kAttributeKeyBrowserType:kAttributeValueChrome}];
+                                            kAttributeKeyBrowserType:kAttributeValueChrome}
+                            sentEventTags:@{kAttributeKeyBrowserType:kAttributeValueChrome}
+                                 sentTags:@{OPTLYEventMetricNameValue:@(INFINITY),
+                                            kAttributeKeyBrowserType:kAttributeValueChrome}];
 }
 
 - (void)testValueMetricWithInvalidObject
 {
     [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameValue:@[@"BAD",@"DATA"],
-                                       kAttributeKeyBrowserType:kAttributeValueChrome}
-                       sentEventTags:@{kAttributeKeyBrowserType:kAttributeValueChrome}];
+                                            kAttributeKeyBrowserType:kAttributeValueChrome}
+                            sentEventTags:@{kAttributeKeyBrowserType:kAttributeValueChrome}
+                                 sentTags:@{kAttributeKeyBrowserType:kAttributeValueChrome}];
 }
 
 #pragma mark - Test revenue Metric and value Metric
@@ -643,10 +664,9 @@ typedef enum : NSUInteger {
     //     "revenue" == money received
     //     "value" == temperature measured
     // There isn't a good reason why both can't be sent in the same event.
-    [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameRevenue:@(kEventRevenue),
-                                       OPTLYEventMetricNameValue:@(kEventValue)}
-                       sentEventTags:@{OPTLYEventMetricNameRevenue:@(kEventRevenue),
-                                       OPTLYEventMetricNameValue:@(kEventValue)}];
+    NSDictionary *tags = @{OPTLYEventMetricNameRevenue:@(kEventRevenue),
+                           OPTLYEventMetricNameValue:@(kEventValue)};
+    [self commonBuildConversionTicketTest:tags sentEventTags:tags sentTags:tags];
 }
 
 #pragma mark - Test BuildConversionTicket:... with Multiple eventTags
@@ -654,22 +674,25 @@ typedef enum : NSUInteger {
 - (void)testBuildConversionTicketWithEventTags
 {
     [self commonBuildConversionTicketTest:@{kAttributeKeyBrowserType:kAttributeValueChrome,
-                                       @"IntegerTag":@15,
-                                       @"BooleanTag":@YES,
-                                       @"FloatTag":@1.23,
-                                       @"InvalidArrayTag":[NSArray new]}
-                       sentEventTags:@{kAttributeKeyBrowserType:kAttributeValueChrome,
-                                       @"IntegerTag":@15,
-                                       @"FloatTag":@1.23,
-                                       @"BooleanTag":@YES}];
+                                            @"IntegerTag":@15,
+                                            @"BooleanTag":@YES,
+                                            @"FloatTag":@1.23,
+                                            @"InvalidArrayTag":[NSArray new]}
+                            sentEventTags:@{kAttributeKeyBrowserType:kAttributeValueChrome,
+                                            @"IntegerTag":@15,
+                                            @"FloatTag":@1.23,
+                                            @"BooleanTag":@YES}
+                                 sentTags:@{kAttributeKeyBrowserType:kAttributeValueChrome,
+                                            @"IntegerTag":@15,
+                                            @"BooleanTag":@YES,
+                                            @"FloatTag":@1.23}];
 }
 
 - (void)testBuildConversionTicketWithRevenueAndEventTags
 {
-    [self commonBuildConversionTicketTest:@{OPTLYEventMetricNameValue:@(kEventRevenue),
-                                       kAttributeKeyBrowserType:kAttributeValueChrome}
-                       sentEventTags:@{OPTLYEventMetricNameValue:@(kEventRevenue),
-                                       kAttributeKeyBrowserType:kAttributeValueChrome}];
+    NSDictionary *tags = @{OPTLYEventMetricNameValue:@(kEventRevenue),
+                           kAttributeKeyBrowserType:kAttributeValueChrome};
+    [self commonBuildConversionTicketTest:tags sentEventTags:tags sentTags:tags];
 }
 
 #pragma mark - Test anonymizeIP
@@ -710,7 +733,8 @@ typedef enum : NSUInteger {
           variationId:nil
            attributes:attributes
              eventKey:kEventWithoutAudienceName
-            eventTags:nil bucketer:self.bucketer userId:kUserId];
+            eventTags:nil tags:nil
+             bucketer:self.bucketer userId:kUserId];
 }
 
 - (void)testCreateImpressionEventWithEmptyAttributeId {
@@ -737,7 +761,8 @@ typedef enum : NSUInteger {
           variationId:nil
            attributes:self.reservedAttributes
              eventKey:kEventWithoutAudienceName
-            eventTags:nil bucketer:self.bucketer userId:kUserId];
+            eventTags:nil tags:nil
+             bucketer:self.bucketer userId:kUserId];
 }
 
 
@@ -767,7 +792,8 @@ typedef enum : NSUInteger {
        experimentKeys:@[kExperimentWithAudienceKey]
           variationId:bucketedVariation.variationId
            attributes:self.attributes
-             eventKey:nil eventTags:nil bucketer:nil userId:kUserId];
+             eventKey:nil eventTags:nil tags:nil
+             bucketer:nil userId:kUserId];
 }
 
 - (void)testImpressionEventWithBotFilteringFalse {
@@ -796,7 +822,8 @@ typedef enum : NSUInteger {
        experimentKeys:@[kExperimentWithAudienceKey]
           variationId:bucketedVariation.variationId
            attributes:self.attributes
-             eventKey:nil eventTags:nil bucketer:nil userId:kUserId];
+             eventKey:nil eventTags:nil tags:nil
+             bucketer:nil userId:kUserId];
 }
 
 - (void)testConversionEventWithoutBotFiltering {
@@ -819,7 +846,8 @@ typedef enum : NSUInteger {
           variationId:nil
            attributes:self.attributes
              eventKey:kEventWithAudienceName
-            eventTags:nil bucketer:self.bucketer userId:kUserId];
+            eventTags:nil tags:nil
+             bucketer:self.bucketer userId:kUserId];
 }
 
 - (void)testConversionEventWithBotFilteringFalse {
@@ -844,7 +872,8 @@ typedef enum : NSUInteger {
           variationId:nil
            attributes:self.attributes
              eventKey:kEventWithAudienceName
-            eventTags:nil bucketer:self.bucketer userId:kUserId];
+            eventTags:nil tags:nil
+             bucketer:self.bucketer userId:kUserId];
 }
 
 #pragma mark - Test BuildImpressionEventTicket:...
@@ -869,7 +898,8 @@ typedef enum : NSUInteger {
         experimentKeys:@[kExperimentWithAudienceKey]
           variationId:bucketedVariation.variationId
            attributes:self.attributes
-             eventKey:nil eventTags:nil bucketer:nil userId:kUserId];
+             eventKey:nil eventTags:nil tags:nil
+             bucketer:nil userId:kUserId];
     
 }
 
@@ -887,7 +917,8 @@ typedef enum : NSUInteger {
         experimentKeys:@[kExperimentWithoutAudienceKey]
           variationId:kVariationWithoutAudienceId
            attributes:self.attributes
-             eventKey:nil eventTags:nil bucketer:nil userId:kUserId];
+             eventKey:nil eventTags:nil tags:nil
+             bucketer:nil userId:kUserId];
 }
 
 - (void)testBuildImpressionEventTicketWithUnknownExperiment
@@ -983,17 +1014,19 @@ typedef enum : NSUInteger {
 
 #pragma mark - Helper Methods
 
-- (void)commonBuildConversionTicketTest:(NSDictionary*)eventTags sentEventTags:(NSDictionary*)sentEventTags
-{
+- (void)commonBuildConversionTicketTest:(NSDictionary*)eventTags
+                          sentEventTags:(NSDictionary*)sentEventTags
+                               sentTags:(NSDictionary*)sentTags {
+    
     // Common subroutine for many of the testBuildEventXxx test methods.
     // Generally, a testBuildEventXxx should make at most one call
-    // to commonBuildConversionTicketTest:sentEventTags: .
+    // to commonBuildConversionTicketTest:sentEventTags:sentTags: .
     NSDictionary *params = [self.eventBuilder buildConversionTicket:self.config
-                                                      bucketer:self.bucketer
-                                                        userId:kUserId
-                                                     eventName:kEventWithAudienceName
-                                                     eventTags:eventTags
-                                                    attributes:self.attributes];
+                                                           bucketer:self.bucketer
+                                                             userId:kUserId
+                                                          eventName:kEventWithAudienceName
+                                                          eventTags:eventTags
+                                                         attributes:self.attributes];
     [self.attributes addEntriesFromDictionary:self.reservedAttributes];
     [self checkTicket:ConversionTicket
             forParams:params
@@ -1002,7 +1035,8 @@ typedef enum : NSUInteger {
           variationId:nil
            attributes:self.attributes
              eventKey:kEventWithAudienceName
-            eventTags:sentEventTags bucketer:self.bucketer userId:kUserId];
+            eventTags:sentEventTags tags:sentTags
+             bucketer:self.bucketer userId:kUserId];
 }
 
 - (void)checkTicket:(Ticket)ticket
@@ -1013,6 +1047,7 @@ typedef enum : NSUInteger {
          attributes:(NSDictionary *)attributes
            eventKey:(NSString *)eventKey
           eventTags:(NSDictionary *)eventTags
+               tags:(NSDictionary *)tags
            bucketer:(OPTLYBucketer *)bucketer
              userId:(NSString *)userId {
     
@@ -1038,8 +1073,7 @@ typedef enum : NSUInteger {
                 }
                 case ConversionTicket: {
                     OPTLYEvent *eventEntity = [config getEventForKey:eventKey];
-                    [self checkConversionTicket:ticketParams config:config eventId:eventEntity.eventId eventKey:eventKey experimentKeys:experimentKeys
-                                    eventTags:eventTags attributes:attributes bucketer:bucketer userId:userId];
+                    [self checkConversionTicket:ticketParams config:config eventId:eventEntity.eventId eventKey:eventKey experimentKeys:experimentKeys eventTags:eventTags tags:tags attributes:attributes bucketer:bucketer userId:userId];
                     break;
                 }
             }
@@ -1080,10 +1114,10 @@ typedef enum : NSUInteger {
                      eventKey:(NSString *)eventKey
                experimentKeys:(NSArray *)experimentKeys
                     eventTags:(NSDictionary *)eventTags
+                         tags:(NSDictionary *)tags
                    attributes:(NSDictionary *)attributes
                      bucketer:(OPTLYBucketer *)bucketer
                        userId:(NSString *)userId {
-    
     
     // check conversion if payload available
     XCTAssertNotNil(params, @"Invalid Conversion ticket");
@@ -1107,7 +1141,7 @@ typedef enum : NSUInteger {
     XCTAssertGreaterThan([events count], 0, @"Didn't find any event");
     
     for (NSDictionary *event in events) {
-        [self checkConversion:event entityId:eventId eventKey:eventKey uuid:@"" eventTags:eventTags];
+        [self checkConversion:event entityId:eventId eventKey:eventKey uuid:@"" eventTags:eventTags tags:tags];
     }
 }
 
@@ -1143,7 +1177,8 @@ typedef enum : NSUInteger {
                entityId:(NSString *)entityId
                eventKey:(NSString *)eventKey
                    uuid:(NSString *)uuid
-              eventTags:(NSDictionary *)eventTags {
+              eventTags:(NSDictionary *)eventTags
+                   tags:(NSDictionary *)tags {
     
     XCTAssert([entityId isEqualToString:params[OPTLYEventParameterKeysEntityId]], @"Invalid entityId.");
     
@@ -1157,23 +1192,16 @@ typedef enum : NSUInteger {
     XCTAssertNotNil(params[OPTLYEventParameterKeysUUID], @"Did not find uuid in conversion event.");
     XCTAssertNotEqual(params[OPTLYEventParameterKeysUUID], uuid, @"Invalid uuid.");
     
-    NSDictionary *tags = params[OPTLYEventParameterKeysTags];
-    [self checkEventTags:eventTags withTags:tags];
+    NSDictionary *sentTags = params[OPTLYEventParameterKeysTags];
+    [self checkEventTags:tags withTags:sentTags];
     [self checkEventTags:eventTags withEvent:params];
 }
 
 - (void)checkEventTags:(NSDictionary *)eventTags
               withTags:(NSDictionary *)tags {
     
-    // check for equal number of tags with event tags
-    XCTAssert([eventTags count] == [tags count], @"Invalid number of event tags.");
-    
-    for (NSString *eventTag in [eventTags allKeys]) {
-        if (!([eventTag isEqualToString:OPTLYEventMetricNameRevenue] || [eventTag isEqualToString:OPTLYEventMetricNameValue])) {
-            XCTAssertNotNil(tags[eventTag], @"Invalid event tag name.");
-            XCTAssert([eventTags[eventTag] isEqual: tags[eventTag]], @"Invalid event tag value.");
-        }
-    }
+    // match tags with event tags. i.e number of tags and their content.
+    XCTAssertEqualObjects(eventTags, tags, @"Invalid tags transmitted in the event");
 }
 
 - (void)checkEventTags:(NSDictionary *)eventTags

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/TestData/test_data_10_experiments.json
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/TestData/test_data_10_experiments.json
@@ -616,7 +616,13 @@
   "projectId": "6377970066",
   "accountId": "6365361536",
   "events": [
-    {
+     {
+     "experimentIds": [
+                       "5555555555"
+                       ],
+     "id": "6370392433",
+     "key": "testEventWithInvalidExperiment"
+     },{
       "experimentIds": [
         "6450630664",
         "6447021179"


### PR DESCRIPTION
There are many test case changes because if eventtag had unexpected revenue value, it was being removed. so we added it again in the tags. @mikeng13 @thomaszurkan-optimizely 