### PR TITLE
fix json model problems so that you can access objects correctly

### DIFF
--- a/OptimizelyDemoApp/AppDelegate.swift
+++ b/OptimizelyDemoApp/AppDelegate.swift
@@ -125,8 +125,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
             })
 #endif
-            let variation = optimizelyClient?.activate((self?.experimentKey)!, userId: (self?.userId)!, attributes: (self?.attributes))
+            let variation = optimizelyClient?.activate((self?.experimentKey)!, userId: (self?.userId)!)
             
+            if let experiments = optimizelyClient?.optimizely?.config?.experiments {
+                for experiment in experiments {
+                    print(experiment.experimentKey)
+                }
+            }
             self?.setRootViewController(optimizelyClient: optimizelyClient, bucketedVariation:variation)
         })
         

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYProjectConfig.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYProjectConfig.h
@@ -49,20 +49,20 @@ NS_ASSUME_NONNULL_END
 /// Flag for Bot Filtering
 @property (nonatomic, strong, nonnull) NSNumber<OPTLYOptional> *botFiltering;
 /// List of Optimizely Experiment objects
-@property (nonatomic, strong, nonnull) NSArray<OPTLYExperiment> *experiments;
+@property (nonatomic, strong, nonnull) NSArray<OPTLYExperiment*><OPTLYExperiment> *experiments;
 /// List of Optimizely Event Type objects
-@property (nonatomic, strong, nonnull) NSArray<OPTLYEvent> *events;
+@property (nonatomic, strong, nonnull) NSArray<OPTLYEvent *><OPTLYEvent> *events;
 /// List of audience ids
-@property (nonatomic, strong, nonnull) NSArray<OPTLYAudience> *audiences;
+@property (nonatomic, strong, nonnull) NSArray<OPTLYAudience *><OPTLYAudience> *audiences;
 /// List of attributes objects
-@property (nonatomic, strong, nonnull) NSArray<OPTLYAttribute> *attributes;
+@property (nonatomic, strong, nonnull) NSArray<OPTLYAttribute*><OPTLYAttribute> *attributes;
 /// List of group objects
-@property (nonatomic, strong, nonnull) NSArray<OPTLYGroup> *groups;
+@property (nonatomic, strong, nonnull) NSArray<OPTLYGroup*><OPTLYGroup> *groups;
 /// List of live variable objects (DEPRECATED)
-@property (nonatomic, strong, nonnull) NSArray<OPTLYVariable, OPTLYOptional> *variables;
+@property (nonatomic, strong, nonnull) NSArray<OPTLYVariable *><OPTLYVariable, OPTLYOptional> *variables;
 
 /// a comprehensive list of experiments that includes experiments being whitelisted (in Groups)
-@property (nonatomic, strong, nullable) NSArray<OPTLYExperiment, Ignore> *allExperiments;
+@property (nonatomic, strong, nullable) NSArray<OPTLYExperiment*><OPTLYExperiment, OPTLYOptional> *allExperiments;
 @property (nonatomic, strong, nullable) id<OPTLYLogger, Ignore> logger;
 @property (nonatomic, strong, nullable) id<OPTLYErrorHandler, Ignore> errorHandler;
 @property (nonatomic, strong, readonly, nullable) id<OPTLYUserProfileService, Ignore> userProfileService;
@@ -72,9 +72,9 @@ NS_ASSUME_NONNULL_END
 /// Returns the client version number
 @property (nonatomic, strong, readonly, nonnull) NSString<Ignore> *clientVersion;
 /// List of Optimizely Feature Flags objects
-@property (nonatomic, strong, nonnull) NSArray<OPTLYFeatureFlag, OPTLYOptional> *featureFlags;
+@property (nonatomic, strong, nonnull) NSArray<OPTLYFeatureFlag*><OPTLYFeatureFlag, OPTLYOptional> *featureFlags;
 /// List of Optimizely Rollouts objects
-@property (nonatomic, strong, nonnull) NSArray<OPTLYRollout, OPTLYOptional> *rollouts;
+@property (nonatomic, strong, nonnull) NSArray<OPTLYRollout*><OPTLYRollout, OPTLYOptional> *rollouts;
 
 /**
  * Initialize the Project Config from a builder block.


### PR DESCRIPTION
The PR fixes the issue with Swift 4.2 accessing the entities in a data model and having to cast them because the protocol is not actually defined.  

The problem is that these were not implemented correctly to start with.  The entities should be what an array should contain.  The protocols are just notations for JSONModel (OPTLYJSONModel).  So, for example:
```
@property (nonatomic, strong, nonnull) NSArray<OPTLYExperiment> *experiments;
```
The above old implementation defines a array of OPTLYExperiment protocol objects.  However, the OPTLYExperiment contains no methods or properties.  The proper declaring is the following:
```
@property (nonatomic, strong, nonnull) NSArray<OPTLYExperiment*><OPTLYExperiment> *experiments;
```
This seems to be a JSONModel specific annotation via the protocols at the end.  

**We should do this for all data model objects using arrays of protocols.
