### PR TITLE
(fix) check the queue size before accessing index

### DIFF
--- a/OptimizelySDKShared/OptimizelySDKShared/OPTLYEventDataStore.m
+++ b/OptimizelySDKShared/OptimizelySDKShared/OPTLYEventDataStore.m
@@ -256,8 +256,10 @@ dispatch_queue_t eventsStorageCacheQueue()
         dispatch_async(eventsStorageCacheQueue(), ^{
             __weak typeof(self) weakSelf = self;
             OPTLYQueue *queue = [weakSelf.eventsCache objectForKey:eventTypeName];
-            NSDictionary *eventJSON = [queue.queue objectAtIndex:[event[@"entityId"] integerValue]];
-            [queue removeItem:eventJSON];
+            if (queue && [queue.queue count] > [event[@"entityId"] integerValue]) {
+                NSDictionary *eventJSON = [queue.queue objectAtIndex:[event[@"entityId"] integerValue]];
+                [queue removeItem:eventJSON];
+            }
         });
         retval = YES;
     }


### PR DESCRIPTION
Report of a crash caused by accessing the queue when it is empty.  Not sure this is actually possible but the safety check added should have been there.