### PR TITLE
(fix) wrap lazy loaded optlyfilemanager in a serial queue

### DIFF
--- a/OptimizelySDKShared/OptimizelySDKShared/OPTLYDataStore.m
+++ b/OptimizelySDKShared/OptimizelySDKShared/OPTLYDataStore.m
@@ -73,7 +73,7 @@ static NSString *const kOPTLYDataStoreEventTypeConversion = @"conversion_events"
         _baseDirectory = [filePath stringByAppendingPathComponent:kOptimizelyDirectory];
 #endif
         
-        _fileManagerCreateQueue = dispatch_queue_create("FileManagerCreateQueue", DISPATCH_QUEUE_SERIAL);
+        _fileManagerCreateQueue = dispatch_queue_create("OptlyFileManagerCreateQueue", DISPATCH_QUEUE_SERIAL);
     }
     return self;
 }

--- a/OptimizelySDKShared/OptimizelySDKShared/OPTLYDataStore.m
+++ b/OptimizelySDKShared/OptimizelySDKShared/OPTLYDataStore.m
@@ -157,11 +157,12 @@ static NSString *const kOPTLYDataStoreEventTypeConversion = @"conversion_events"
 }
 
 - (void) loadFileManagerIfNecessary {
-    __block OPTLYDataStore *weakSelf = self;
+    __block __weak OPTLYDataStore *weakSelf = self;
     dispatch_sync(_fileManagerCreateQueue, ^{
         if (weakSelf != nil) {
-            if (weakSelf->_fileManager == nil) {
-                weakSelf->_fileManager = [[OPTLYFileManager alloc] initWithBaseDir:weakSelf.baseDirectory];
+            OPTLYDataStore *strongSelf = weakSelf;
+            if (strongSelf->_fileManager == nil) {
+                strongSelf->_fileManager = [[OPTLYFileManager alloc] initWithBaseDir:strongSelf.baseDirectory];
             }
         }
     });

--- a/OptimizelySDKShared/OptimizelySDKShared/OPTLYDataStore.m
+++ b/OptimizelySDKShared/OptimizelySDKShared/OPTLYDataStore.m
@@ -71,6 +71,8 @@ static NSString *const kOPTLYDataStoreEventTypeConversion = @"conversion_events"
         filePath = NSTemporaryDirectory();
         _baseDirectory = [filePath stringByAppendingPathComponent:kOptimizelyDirectory];
 #endif
+        _fileManager = [[OPTLYFileManager alloc] initWithBaseDir:self.baseDirectory];
+
     }
     return self;
 }
@@ -94,9 +96,6 @@ static NSString *const kOPTLYDataStoreEventTypeConversion = @"conversion_events"
 }
 
 - (OPTLYFileManager *)fileManager {
-    if (!_fileManager) {
-        _fileManager = [[OPTLYFileManager alloc] initWithBaseDir:self.baseDirectory];
-    }
     return _fileManager;
 }
 

--- a/OptimizelySDKShared/OptimizelySDKShared/OPTLYDataStore.m
+++ b/OptimizelySDKShared/OptimizelySDKShared/OPTLYDataStore.m
@@ -149,6 +149,14 @@ static NSString *const kOPTLYDataStoreEventTypeConversion = @"conversion_events"
 
 # pragma mark - File Manager Methods
 - (OPTLYFileManager *)fileManager {
+    if (_fileManager == nil) {
+        [self loadFileManagerIfNecessary];
+    }
+    return _fileManager;
+
+}
+
+- (void) loadFileManagerIfNecessary {
     __block OPTLYDataStore *weakSelf = self;
     dispatch_sync(_fileManagerCreateQueue, ^{
         if (weakSelf != nil) {
@@ -157,9 +165,6 @@ static NSString *const kOPTLYDataStoreEventTypeConversion = @"conversion_events"
             }
         }
     });
-    
-    return _fileManager;
-
 }
 
 - (BOOL)saveFile:(nonnull NSString *)fileName

--- a/OptimizelySDKShared/OptimizelySDKShared/OPTLYDataStore.m
+++ b/OptimizelySDKShared/OptimizelySDKShared/OPTLYDataStore.m
@@ -152,8 +152,8 @@ static NSString *const kOPTLYDataStoreEventTypeConversion = @"conversion_events"
     __block OPTLYDataStore *weakSelf = self;
     dispatch_sync(_fileManagerCreateQueue, ^{
         if (weakSelf != nil) {
-            if (weakSelf.fileManager != nil) {
-                weakSelf.fileManager = [[OPTLYFileManager alloc] initWithBaseDir:self.baseDirectory];
+            if (weakSelf->_fileManager == nil) {
+                weakSelf->_fileManager = [[OPTLYFileManager alloc] initWithBaseDir:weakSelf.baseDirectory];
             }
         }
     });

--- a/OptimizelySDKShared/OptimizelySDKShared/OPTLYDataStore.m
+++ b/OptimizelySDKShared/OptimizelySDKShared/OPTLYDataStore.m
@@ -95,10 +95,6 @@ static NSString *const kOPTLYDataStoreEventTypeConversion = @"conversion_events"
     return _eventDataStore;
 }
 
-- (OPTLYFileManager *)fileManager {
-    return _fileManager;
-}
-
 - (BOOL)removeAll:(NSError * _Nullable __autoreleasing * _Nullable)error {
     BOOL ok = YES;
     [self removeAllUserData];


### PR DESCRIPTION

## Summary
- Crash came in where the obj send failed for OPTLYFileManager.  Since this class is lazy loaded, it may cause problems in a multi-threaded environment.  So, wrapping it in a synch queue call.

The "why", or other context.

## Test plan
No new tests written yet.

## Issues
3823
