### PR TITLE
feat (audiences): Audience combinations

### DIFF
--- a/OptimizelySDKCore/OptimizelySDKCore.xcodeproj/project.pbxproj
+++ b/OptimizelySDKCore/OptimizelySDKCore.xcodeproj/project.pbxproj
@@ -225,14 +225,18 @@
 		90855D0120ED254600A97BEC /* OPTLYControlAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 90855CFC20ED237F00A97BEC /* OPTLYControlAttributes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		90855D0D20ED2E0100A97BEC /* OPTLYControlAttributes.m in Sources */ = {isa = PBXBuildFile; fileRef = 90855D0420ED2B0200A97BEC /* OPTLYControlAttributes.m */; };
 		90855D0E20ED2E0300A97BEC /* OPTLYControlAttributes.m in Sources */ = {isa = PBXBuildFile; fileRef = 90855D0420ED2B0200A97BEC /* OPTLYControlAttributes.m */; };
-		C77EA0C7218843320021781A /* OPTLYTypedAudienceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C77EA0C52188431E0021781A /* OPTLYTypedAudienceTest.m */; };
-		C77EA0C8218843320021781A /* OPTLYTypedAudienceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C77EA0C52188431E0021781A /* OPTLYTypedAudienceTest.m */; };
-		C7ACD4FE218C2E4A008EC52E /* typed_audience_datafile.json in Resources */ = {isa = PBXBuildFile; fileRef = C7ACD4FD218C2E4A008EC52E /* typed_audience_datafile.json */; };
-		C7ACD4FF218C2E51008EC52E /* typed_audience_datafile.json in Resources */ = {isa = PBXBuildFile; fileRef = C7ACD4FD218C2E4A008EC52E /* typed_audience_datafile.json */; };
 		C77958C3219BFBC300B4CA89 /* OPTLYNSObject+Validation.h in Headers */ = {isa = PBXBuildFile; fileRef = C77958C0219BFBA000B4CA89 /* OPTLYNSObject+Validation.h */; };
 		C77958C4219BFBC400B4CA89 /* OPTLYNSObject+Validation.h in Headers */ = {isa = PBXBuildFile; fileRef = C77958C0219BFBA000B4CA89 /* OPTLYNSObject+Validation.h */; };
 		C77958C5219BFBC700B4CA89 /* OPTLYNSObject+Validation.m in Sources */ = {isa = PBXBuildFile; fileRef = C77958C1219BFBA000B4CA89 /* OPTLYNSObject+Validation.m */; };
 		C77958C6219BFBC800B4CA89 /* OPTLYNSObject+Validation.m in Sources */ = {isa = PBXBuildFile; fileRef = C77958C1219BFBA000B4CA89 /* OPTLYNSObject+Validation.m */; };
+		C77EA0C7218843320021781A /* OPTLYTypedAudienceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C77EA0C52188431E0021781A /* OPTLYTypedAudienceTest.m */; };
+		C77EA0C8218843320021781A /* OPTLYTypedAudienceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C77EA0C52188431E0021781A /* OPTLYTypedAudienceTest.m */; };
+		C78F98B7219ADEA600808062 /* OPTLYAudienceBaseCondition.h in Headers */ = {isa = PBXBuildFile; fileRef = C78F98B4219ADE9600808062 /* OPTLYAudienceBaseCondition.h */; };
+		C78F98B8219ADEA700808062 /* OPTLYAudienceBaseCondition.h in Headers */ = {isa = PBXBuildFile; fileRef = C78F98B4219ADE9600808062 /* OPTLYAudienceBaseCondition.h */; };
+		C78F98B9219ADEAB00808062 /* OPTLYAudienceBaseCondition.m in Sources */ = {isa = PBXBuildFile; fileRef = C78F98B5219ADE9600808062 /* OPTLYAudienceBaseCondition.m */; };
+		C78F98BA219ADEAB00808062 /* OPTLYAudienceBaseCondition.m in Sources */ = {isa = PBXBuildFile; fileRef = C78F98B5219ADE9600808062 /* OPTLYAudienceBaseCondition.m */; };
+		C7ACD4FE218C2E4A008EC52E /* typed_audience_datafile.json in Resources */ = {isa = PBXBuildFile; fileRef = C7ACD4FD218C2E4A008EC52E /* typed_audience_datafile.json */; };
+		C7ACD4FF218C2E51008EC52E /* typed_audience_datafile.json in Resources */ = {isa = PBXBuildFile; fileRef = C7ACD4FD218C2E4A008EC52E /* typed_audience_datafile.json */; };
 		EA064BC71DD3FC8800DF7537 /* OPTLYQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = EA064BC51DD3FC8800DF7537 /* OPTLYQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA064BC81DD3FC8800DF7537 /* OPTLYQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = EA064BC51DD3FC8800DF7537 /* OPTLYQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA064BC91DD3FC8800DF7537 /* OPTLYQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = EA064BC61DD3FC8800DF7537 /* OPTLYQueue.m */; };
@@ -637,10 +641,12 @@
 		A52039FD7B704890859320C4 /* Pods-OptimizelySDKCoreiOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OptimizelySDKCoreiOSTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-OptimizelySDKCoreiOSTests/Pods-OptimizelySDKCoreiOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		B333468714C0D4A8633103EF /* Pods-OptimizelySDKCoreiOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OptimizelySDKCoreiOSTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-OptimizelySDKCoreiOSTests/Pods-OptimizelySDKCoreiOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		BE0C3BD9DC6186DB98A667C2 /* Pods_OptimizelySDKCoreTVOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OptimizelySDKCoreTVOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		C77EA0C52188431E0021781A /* OPTLYTypedAudienceTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OPTLYTypedAudienceTest.m; sourceTree = "<group>"; };
-		C7ACD4FD218C2E4A008EC52E /* typed_audience_datafile.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = typed_audience_datafile.json; sourceTree = "<group>"; };
 		C77958C0219BFBA000B4CA89 /* OPTLYNSObject+Validation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OPTLYNSObject+Validation.h"; sourceTree = "<group>"; };
 		C77958C1219BFBA000B4CA89 /* OPTLYNSObject+Validation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "OPTLYNSObject+Validation.m"; sourceTree = "<group>"; };
+		C77EA0C52188431E0021781A /* OPTLYTypedAudienceTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OPTLYTypedAudienceTest.m; sourceTree = "<group>"; };
+		C78F98B4219ADE9600808062 /* OPTLYAudienceBaseCondition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OPTLYAudienceBaseCondition.h; sourceTree = "<group>"; };
+		C78F98B5219ADE9600808062 /* OPTLYAudienceBaseCondition.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OPTLYAudienceBaseCondition.m; sourceTree = "<group>"; };
+		C7ACD4FD218C2E4A008EC52E /* typed_audience_datafile.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = typed_audience_datafile.json; sourceTree = "<group>"; };
 		E2E7211C032DF7A75264FDDB /* Pods-OptimizelySDKCoreTVOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OptimizelySDKCoreTVOSTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-OptimizelySDKCoreTVOSTests/Pods-OptimizelySDKCoreTVOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		EA064BC51DD3FC8800DF7537 /* OPTLYQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OPTLYQueue.h; sourceTree = "<group>"; };
 		EA064BC61DD3FC8800DF7537 /* OPTLYQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OPTLYQueue.m; sourceTree = "<group>"; };
@@ -1053,6 +1059,8 @@
 				EA2FAA531DC6F57100B1D81B /* OPTLYAttribute.m */,
 				EA2FAA541DC6F57100B1D81B /* OPTLYAudience.h */,
 				EA2FAA551DC6F57100B1D81B /* OPTLYAudience.m */,
+				C78F98B4219ADE9600808062 /* OPTLYAudienceBaseCondition.h */,
+				C78F98B5219ADE9600808062 /* OPTLYAudienceBaseCondition.m */,
 				EA2FAA561DC6F57100B1D81B /* OPTLYBaseCondition.h */,
 				EA2FAA571DC6F57100B1D81B /* OPTLYBaseCondition.m */,
 				EA2FAA581DC6F57100B1D81B /* OPTLYCondition.h */,
@@ -1366,6 +1374,7 @@
 				EA2FAAA01DC6F57100B1D81B /* OPTLYDatafileKeys.h in Headers */,
 				EA2FAAB21DC6F57200B1D81B /* OPTLYEventAudience.h in Headers */,
 				EA2FAA881DC6F57100B1D81B /* OPTLYAttribute.h in Headers */,
+				C78F98B7219ADEA600808062 /* OPTLYAudienceBaseCondition.h in Headers */,
 				EA2FAAE81DC6F57200B1D81B /* OPTLYEventParameterKeys.h in Headers */,
 				EA2FAADC1DC6F57200B1D81B /* OPTLYEventLayerState.h in Headers */,
 				EA2FAAEE1DC6F57200B1D81B /* OPTLYEventRelatedEvent.h in Headers */,
@@ -1432,6 +1441,7 @@
 				EA2FAB131DC6F57200B1D81B /* OPTLYTrafficAllocation.h in Headers */,
 				EA2FAA891DC6F57100B1D81B /* OPTLYAttribute.h in Headers */,
 				EA2FAA9B1DC6F57100B1D81B /* OPTLYCondition.h in Headers */,
+				C78F98B8219ADEA700808062 /* OPTLYAudienceBaseCondition.h in Headers */,
 				EA2FAAAD1DC6F57200B1D81B /* OPTLYEvent.h in Headers */,
 				EA2FAA8F1DC6F57100B1D81B /* OPTLYAudience.h in Headers */,
 				EA2FAB071DC6F57200B1D81B /* OPTLYGroup.h in Headers */,
@@ -1961,6 +1971,7 @@
 				EA2C242F1DE6A2470063ADA0 /* OPTLYProjectConfigBuilder.m in Sources */,
 				EA8FD0E11DE9798E00D950AD /* OPTLYNetworkService.m in Sources */,
 				EA2FAC171DC6FFC600B1D81B /* OPTLYEventMetric.m in Sources */,
+				C78F98B9219ADEAB00808062 /* OPTLYAudienceBaseCondition.m in Sources */,
 				EA2FAC181DC6FFC600B1D81B /* OPTLYEventParameterKeys.m in Sources */,
 				EA2FAC191DC6FFC600B1D81B /* OPTLYEventRelatedEvent.m in Sources */,
 				EA2FAC1B1DC6FFC600B1D81B /* OPTLYEventView.m in Sources */,
@@ -2054,6 +2065,7 @@
 				EA2FABF21DC6FFA100B1D81B /* OPTLYEventMetric.m in Sources */,
 				EA2FABF31DC6FFA100B1D81B /* OPTLYEventParameterKeys.m in Sources */,
 				EA2FABF41DC6FFA100B1D81B /* OPTLYEventRelatedEvent.m in Sources */,
+				C78F98BA219ADEAB00808062 /* OPTLYAudienceBaseCondition.m in Sources */,
 				3E858C881F4227F100D53856 /* OPTLYJSONModel.m in Sources */,
 				EA2FABF61DC6FFA100B1D81B /* OPTLYEventView.m in Sources */,
 				EA2FABF71DC6FFA100B1D81B /* OPTLYExperiment.m in Sources */,

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYAudience.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYAudience.m
@@ -16,6 +16,7 @@
 
 #import "OPTLYAudience.h"
 #import "OPTLYDatafileKeys.h"
+#import "OPTLYNSObject+Validation.h"
 
 @implementation OPTLYAudience
 
@@ -27,17 +28,7 @@
 }
 
 - (void)setConditionsWithNSString:(NSString *)string {
-    NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
-    
-    NSError *err = nil;
-    NSArray *array = [NSJSONSerialization JSONObjectWithData:data
-                                                     options:NSJSONReadingAllowFragments
-                                                       error:&err];
-    if (err != nil) {
-        NSException *exception = [[NSException alloc] initWithName:err.domain reason:err.localizedFailureReason userInfo:@{@"Error" : err}];
-        @throw exception;
-    }
-    
+    NSArray *array = [string getValidConditionsArray];
     [self setConditionsWithNSArray:array];
 }
 
@@ -50,9 +41,9 @@
     }
 }
 
-- (nullable NSNumber *)evaluateConditionsWithAttributes:(NSDictionary<NSString *, NSObject *> *)attributes {
+- (nullable NSNumber *)evaluateConditionsWithAttributes:(NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
     for (NSObject<OPTLYCondition> *condition in self.conditions) {
-        NSNumber *result = [condition evaluateConditionsWithAttributes:attributes];
+        NSNumber *result = [condition evaluateConditionsWithAttributes:attributes projectConfig:config];
         if (result != NULL && [result boolValue] == true) {
             // if user satisfies any conditions, return true.
             return [NSNumber numberWithBool:true];

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYAudienceBaseCondition.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYAudienceBaseCondition.h
@@ -1,0 +1,33 @@
+/****************************************************************************
+ * Copyright 2018, Optimizely, Inc. and contributors                   *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+#ifdef UNIVERSAL
+#import "OPTLYJSONModelLib.h"
+#else
+#import <OptimizelySDKCore/OPTLYJSONModelLib.h>
+#endif
+#import "OPTLYCondition.h"
+
+@protocol OPTLYAudienceBaseCondition
+@end
+
+@interface OPTLYAudienceBaseCondition : NSObject <OPTLYCondition>
+
+@property (nonatomic, strong) NSString *audienceId;
++(BOOL)isBaseConditionJSON:(NSData *)jsonData;
+
+@end
+

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYAudienceBaseCondition.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYAudienceBaseCondition.m
@@ -1,0 +1,41 @@
+/****************************************************************************
+ * Copyright 2018, Optimizely, Inc. and contributors                   *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+#import "OPTLYAudienceBaseCondition.h"
+#import "OPTLYAudience.h"
+
+@implementation OPTLYAudienceBaseCondition
+
++ (BOOL) isBaseConditionJSON:(NSData *)jsonData {
+    return [jsonData isKindOfClass:[NSString class]];
+}
+
+- (nullable NSNumber *)evaluateConditionsWithAttributes:(NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
+    if (attributes == nil) {
+        // if the user did not pass in attributes, return false
+        return [NSNumber numberWithBool:false];
+    }
+    
+    OPTLYAudience *audience = [config getAudienceForId:self.audienceId];
+    BOOL areAttributesValid = [[audience evaluateConditionsWithAttributes:attributes projectConfig:config] boolValue];
+    if (areAttributesValid) {
+        return [NSNumber numberWithBool:true];;
+    }
+    
+    return [NSNumber numberWithBool:false];
+}
+
+@end

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYBaseCondition.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYBaseCondition.m
@@ -16,6 +16,7 @@
 
 #import "OPTLYBaseCondition.h"
 #import "OPTLYDatafileKeys.h"
+#import "OPTLYNSObject+Validation.h"
 
 @implementation OPTLYBaseCondition
 
@@ -54,13 +55,13 @@
     if ([self.value isKindOfClass:[NSString class]] && [userAttribute isKindOfClass:[NSString class]]) {
         success = [NSNumber numberWithBool:[self.value isEqual:userAttribute]];
     }
-    else if ([self isNumeric:self.value] && [self isNumeric:userAttribute]) {
+    else if ([self.value isNumeric] && [userAttribute isNumeric]) {
         success = [NSNumber numberWithBool:[self.value isEqual:userAttribute]];
     }
     else if ([self.value isKindOfClass:[NSNull class]] && [userAttribute isKindOfClass:[NSNull class]]) {
         success = [NSNumber numberWithBool:[self.value isEqual:userAttribute]];
     }
-    else if ([self isBool:self.value] && [self isBool:userAttribute]) {
+    else if ([self.value isBool] && [userAttribute isBool]) {
         success = [NSNumber numberWithBool:[self.value isEqual:userAttribute]];
     }
     return success;
@@ -86,7 +87,7 @@
 -(nullable NSNumber *)evaluateMatchTypeGreaterThan:(NSDictionary<NSString *, NSObject *> *)attributes{
     // check if user attributes contain a value greater than our value
     NSObject *userAttribute = [attributes objectForKey:self.name];
-    BOOL userValueAndOurValueHaveNSNumberClassTypes = [self isNumeric:self.value] && [self isNumeric:userAttribute];
+    BOOL userValueAndOurValueHaveNSNumberClassTypes = [self.value isNumeric] && [userAttribute isNumeric];
     
     if (userValueAndOurValueHaveNSNumberClassTypes) {
         NSNumber *ourValue = (NSNumber *)self.value;
@@ -99,7 +100,7 @@
 -(nullable NSNumber *)evaluateMatchTypeLessThan:(NSDictionary<NSString *, NSObject *> *)attributes{
     // check if user attributes contain a value lesser than our value
     NSObject *userAttribute = [attributes objectForKey:self.name];
-    BOOL userValueAndOurValueHaveNSNumberClassTypes = [self isNumeric:self.value] && [self isNumeric:userAttribute];
+    BOOL userValueAndOurValueHaveNSNumberClassTypes = [self.value isNumeric] && [userAttribute isNumeric];
     
     if (userValueAndOurValueHaveNSNumberClassTypes) {
         NSNumber *ourValue = (NSNumber *)self.value;
@@ -149,40 +150,9 @@
 /**
  * Evaluates the condition against the user attributes, returns NULL if invalid.
  */
-- (nullable NSNumber *)evaluateConditionsWithAttributes:(NSDictionary<NSString *, NSObject *> *)attributes {
+- (nullable NSNumber *)evaluateConditionsWithAttributes:(NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
     // check user attribute value for the condition and match type against our condition value
     return [self evaluateCustomMatchType: attributes];
-}
-
--(BOOL)isNumeric:(NSObject *)object{
-    //Check if given object is acceptable numeric type
-    if ([object isKindOfClass:[NSNumber class]]) {
-        NSNumber *number = (NSNumber*)object;
-        CFTypeID cfnumID = CFNumberGetTypeID(); // the type ID of CFNumber
-        CFTypeID numID = CFGetTypeID((__bridge CFTypeRef)(number)); // the type ID of num
-        if (numID == cfnumID) {
-            // Require real numbers (not infinite or NaN).
-            double doubleValue = [number doubleValue];
-            if (isfinite(doubleValue)) {
-                return true;
-            }
-            else {
-                return false;
-            }
-        }
-    }
-    return false;
-}
-
--(BOOL)isBool:(NSObject *)object{
-    //Check if given object is acceptable boolean type
-    if ([object isKindOfClass:[NSNumber class]]) {
-        NSNumber *number = (NSNumber*)object;
-        CFTypeID boolID = CFBooleanGetTypeID(); // the type ID of CFBoolean
-        CFTypeID numID = CFGetTypeID((__bridge CFTypeRef)(number)); // the type ID of num
-        return numID == boolID;
-    }
-    return false;
 }
 
 @end

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYCondition.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYCondition.h
@@ -15,13 +15,14 @@
  ***************************************************************************/
 
 #import <Foundation/Foundation.h>
+#import "OPTLYProjectConfig.h"
 
 @protocol OPTLYCondition
 
 /**
  * Evaluate the condition against the user attributes.
  */
-- (nullable NSNumber *)evaluateConditionsWithAttributes:(NSDictionary<NSString *, NSObject *> *)attributes;
+- (nullable NSNumber *)evaluateConditionsWithAttributes:(NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config;
 
 @end
 
@@ -29,7 +30,10 @@
 
 + (NSArray<OPTLYCondition *><OPTLYCondition> *)deserializeJSONArray:(NSArray *)jsonArray
                                             error:(NSError * __autoreleasing *)error;
-+ (NSArray<OPTLYCondition *><OPTLYCondition> *)deserializeJSONArray:(NSArray *)jsonArray;
++ (NSArray<OPTLYCondition> *)deserializeJSONArray:(NSArray *)jsonArray;
++ (NSArray<OPTLYCondition> *)deserializeAudienceConditionsJSONArray:(NSArray *)jsonArray
+                                            error:(NSError * __autoreleasing *)error;
++ (NSArray<OPTLYCondition> *)deserializeAudienceConditionsJSONArray:(NSArray *)jsonArray;
 
 @end
 

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYDatafileKeys.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYDatafileKeys.h
@@ -36,6 +36,7 @@ extern NSString * const OPTLYDatafileKeysExperimentKey;
 extern NSString * const OPTLYDatafileKeysExperimentStatus;
 extern NSString * const OPTLYDatafileKeysExperimentTrafficAllocation;
 extern NSString * const OPTLYDatafileKeysExperimentAudienceIds;
+extern NSString * const OPTLYDatafileKeysExperimentAudienceConditions;
 extern NSString * const OPTLYDatafileKeysExperimentVariations;
 extern NSString * const OPTLYDatafileKeysExperimentForcedVariations;
 extern NSString * const OPTLYDatafileKeysExperimentLayerId;

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYDatafileKeys.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYDatafileKeys.m
@@ -32,6 +32,7 @@ NSString * const OPTLYDatafileKeysExperimentKey = @"key";
 NSString * const OPTLYDatafileKeysExperimentStatus = @"status";
 NSString * const OPTLYDatafileKeysExperimentTrafficAllocation = @"trafficAllocation";
 NSString * const OPTLYDatafileKeysExperimentAudienceIds = @"audienceIds";
+NSString * const OPTLYDatafileKeysExperimentAudienceConditions = @"audienceConditions";
 NSString * const OPTLYDatafileKeysExperimentVariations = @"variations";
 NSString * const OPTLYDatafileKeysExperimentForcedVariations = @"forcedVariations";
 NSString * const OPTLYDatafileKeysExperimentLayerId = @"layerId";

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYDecisionService.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYDecisionService.m
@@ -62,7 +62,7 @@
     
     // Acquire bucketingId .
     NSString *bucketingId = [self getBucketingId:userId attributes:attributes];
-
+    
     // ---- check if the experiment is running ----
     if (![self isExperimentActive:self.config
                     experimentKey:experimentKey]) {
@@ -74,7 +74,7 @@
     if (bucketedVariation != nil) {
         return bucketedVariation;
     }
-
+    
     // ---- check if the experiment is whitelisted ----
     if ([self checkWhitelistingForUser:userId experiment:experiment]) {
         OPTLYVariation *whitelistedVariation = [self getWhitelistedVariationForUser:userId experiment:experiment];
@@ -108,7 +108,7 @@
     
     // ---- check if the user passes audience targeting before bucketing ----
     if ([self userPassesTargeting:self.config
-                    experiment:experiment
+                       experiment:experiment
                            userId:userId
                        attributes:attributes]) {
         
@@ -125,8 +125,8 @@
 }
 
 - (OPTLYFeatureDecision *)getVariationForFeature:(OPTLYFeatureFlag *)featureFlag
-                                    userId:(NSString *)userId
-                                attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
+                                          userId:(NSString *)userId
+                                      attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
     
     //Evaluate in this order:
     
@@ -179,9 +179,9 @@
     OPTLYExperiment *experiment = nil;
     NSString *logMessage = [NSString stringWithFormat:OPTLYLoggerMessagesDecisionServiceUserNotBucketed, bucketingId, group.groupId];
     if (bucketer)
-    experiment = [bucketer bucketToExperiment:group withBucketingId:bucketingId];
+        experiment = [bucketer bucketToExperiment:group withBucketingId:bucketingId];
     if (experiment)
-    logMessage = [NSString stringWithFormat:OPTLYLoggerMessagesDecisionServiceUserBucketed, bucketingId, experiment.experimentKey, group.groupId];
+        logMessage = [NSString stringWithFormat:OPTLYLoggerMessagesDecisionServiceUserBucketed, bucketingId, experiment.experimentKey, group.groupId];
     
     [self.config.logger logMessage:logMessage
                          withLevel:OptimizelyLogLevelDebug];
@@ -226,8 +226,8 @@
 }
 
 - (OPTLYFeatureDecision *)getVariationForFeatureExperiment:(OPTLYFeatureFlag *)featureFlag
-                                              userId:(NSString *)userId
-                                          attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
+                                                    userId:(NSString *)userId
+                                                attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
     
     NSString *featureFlagKey = featureFlag.key;
     NSArray *experimentIds = featureFlag.experimentIds;
@@ -262,8 +262,8 @@
 }
 
 - (OPTLYFeatureDecision *)getVariationForFeatureRollout:(OPTLYFeatureFlag *)featureFlag
-                                           userId:(NSString *)userId
-                                       attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
+                                                 userId:(NSString *)userId
+                                             attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
     
     NSString *bucketing_id = [self getBucketingId:userId attributes:attributes];
     NSString *featureFlagKey = featureFlag.key;
@@ -446,8 +446,79 @@
     return variationId;
 }
 
+- (nullable NSNumber *)evaluateAudienceWithId:(NSString *)audienceId
+                                       config:(OPTLYProjectConfig *)config
+                                   attributes:(NSDictionary<NSString *, NSObject *> *)attributes
+{
+    OPTLYAudience *audience = [config getAudienceForId:audienceId];
+    return [audience evaluateConditionsWithAttributes:attributes projectConfig:config];
+}
+
+- (BOOL)evaluateAudienceIdsForExperiment:(OPTLYExperiment *)experiment
+                                  config:(OPTLYProjectConfig *)config
+                              attributes:(NSDictionary<NSString *, NSObject *> *)attributes
+{
+    NSArray *audienceIds = experiment.audienceIds;
+    // if there are no audiences, ALL users should be part of the experiment
+    if ([audienceIds count] == 0) {
+        return true;
+    }
+    
+    for (NSString *audienceId in audienceIds) {
+        BOOL areAttributesValid = [[self evaluateAudienceWithId:audienceId config:config attributes:attributes] boolValue];
+        if (areAttributesValid) {
+            return true;
+        }
+    }
+    return false;
+}
+
+- (BOOL)evaluateAudienceConditionsForExperiment:(OPTLYExperiment *)experiment
+                                         config:(OPTLYProjectConfig *)config
+                                     attributes:(NSDictionary<NSString *, NSObject *> *)attributes
+{
+    if (experiment.audienceConditions.count == 0) {
+        return true;
+    }
+    BOOL areAttributesValid = [[experiment evaluateConditionsWithAttributes:attributes projectConfig:config] boolValue];
+    if (areAttributesValid) {
+        return areAttributesValid;
+    }
+    return false;
+}
+
+// Returns true if evaluation should be done using audience conditions, else returns false
+- (BOOL)shouldEvaluateUsingAudienceConditions:(OPTLYExperiment *)experiment
+{
+    return experiment.audienceConditions != nil;
+}
+
+// Returns empty dictionary if attributes nil
+- (NSDictionary<NSString *, NSObject *> *)validateAttributes:(NSDictionary<NSString *, NSObject *> *)attributes
+{
+    // if there are audiences, but no user attributes, Defaults to empty attributes
+    if (attributes == nil) {
+        return @{};
+    }
+    return attributes;
+}
+
+- (BOOL)isUserInExperiment:(OPTLYProjectConfig *)config
+                experiment:(OPTLYExperiment *)experiment
+                attributes:(NSDictionary<NSString *, NSObject *> *)attributes
+{
+    attributes = [self validateAttributes:attributes];
+    
+    // if there are audience conditions, evaluate them, else evaluate audience Ids
+    if ([self shouldEvaluateUsingAudienceConditions:experiment]) {
+        return [self evaluateAudienceConditionsForExperiment:experiment config:config attributes:attributes];
+    }
+    
+    return [self evaluateAudienceIdsForExperiment:experiment config:config attributes:attributes];
+}
+
 - (BOOL)userPassesTargeting:(OPTLYProjectConfig *)config
-              experiment:(OPTLYExperiment *)experiment
+                 experiment:(OPTLYExperiment *)experiment
                      userId:(NSString *)userId
                  attributes:(NSDictionary<NSString *, NSObject *> *)attributes
 {
@@ -460,7 +531,7 @@
     
     return isUserInExperiment;
 }
-    
+
 - (BOOL)isExperimentActive:(OPTLYProjectConfig *)config
              experimentKey:(NSString *)experimentKey
 {
@@ -475,31 +546,5 @@
     }
     return true;
 }
-
-- (BOOL)isUserInExperiment:(OPTLYProjectConfig *)config
-             experiment:(OPTLYExperiment *)experiment
-                attributes:(NSDictionary<NSString *, NSObject *> *)attributes
-{
-    NSArray *audiences = experiment.audienceIds;
-    
-    // if there are no audiences, ALL users should be part of the experiment
-    if ([audiences count] == 0) {
-        return true;
-    }
-    
-    // if there are audiences, but no user attributes, Defaults to empty attributes
-    if (attributes == nil) {
-        attributes = @{};
-    }
-    
-    for (NSString *audienceId in audiences) {
-        OPTLYAudience *audience = [config getAudienceForId:audienceId];
-        BOOL areAttributesValid = [[audience evaluateConditionsWithAttributes:attributes] boolValue];
-        if (areAttributesValid) {
-            return true;
-        }
-    }
-    
-    return false;
-}
 @end
+

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYExperiment.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYExperiment.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2016,2018, Optimizely, Inc. and contributors                        *
+ * Copyright 2016,2018, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -20,6 +20,7 @@
 #else
     #import <OptimizelySDKCore/OPTLYJSONModelLib.h>
 #endif
+#import "OPTLYCondition.h"
 
 @class OPTLYVariation, OPTLYTrafficAllocation, OPTLYVariation;
 @protocol OPTLYTrafficAllocation, OPTLYVariation;
@@ -35,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 extern NSString * const OPTLYExperimentStatusRunning;
 NS_ASSUME_NONNULL_END
 
-@interface OPTLYExperiment : OPTLYJSONModel
+@interface OPTLYExperiment : OPTLYJSONModel <OPTLYCondition>
 
 /// The experiment's ID.
 @property (nonatomic, strong, nonnull) NSString *experimentId;
@@ -53,6 +54,8 @@ NS_ASSUME_NONNULL_END
 @property (nonatomic, strong, nonnull) NSArray<OPTLYVariation *><OPTLYVariation> *variations;
 /// A dictionary indicating the forced and control variation
 @property (nonatomic, strong, nonnull) NSDictionary<NSString *, NSString *> *forcedVariations;
+/// Audience evaluator conditions
+@property (nonatomic, strong, nullable) NSArray<OPTLYCondition *><OPTLYCondition, OPTLYOptional> *audienceConditions;
 /// Personalization layer id
 @property (nonatomic, strong, nonnull) NSString *layerId;
 
@@ -63,5 +66,7 @@ NS_ASSUME_NONNULL_END
 
 /// Determines if the experiment is running
 - (BOOL)isExperimentRunning;
+/// Override OPTLYJSONModel set conditions
+- (void)setAudienceConditionsWithNSString:(NSString *)string;
 
 @end

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYExperiment.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYExperiment.m
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2016, Optimizely, Inc. and contributors                        *
+ * Copyright 2016,2018, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -17,6 +17,7 @@
 #import "OPTLYExperiment.h"
 #import "OPTLYDatafileKeys.h"
 #import "OPTLYVariation.h"
+#import "OPTLYNSObject+Validation.h"
 
 NSString * const OPTLYExperimentStatusRunning = @"Running";
 
@@ -34,9 +35,32 @@ NSString * const OPTLYExperimentStatusRunning = @"Running";
 + (OPTLYJSONKeyMapper*)keyMapper
 {
     return [[OPTLYJSONKeyMapper alloc] initWithDictionary:@{ OPTLYDatafileKeysExperimentId   : @"experimentId",
-                                                        OPTLYDatafileKeysExperimentKey  : @"experimentKey",
-                                                        OPTLYDatafileKeysExperimentTrafficAllocation : @"trafficAllocations"
-                                                        }];
+                                                             OPTLYDatafileKeysExperimentKey  : @"experimentKey",
+                                                             OPTLYDatafileKeysExperimentTrafficAllocation : @"trafficAllocations"
+                                                             }];
+}
+
+- (void)setAudienceConditionsWithNSString:(NSString *)string {
+    NSError *err = nil;
+    NSArray *array = [string getValidAudienceConditionsArray];
+    self.audienceConditions = [OPTLYCondition deserializeAudienceConditionsJSONArray:array error:&err];
+    
+    if (err != nil) {
+        NSException *exception = [[NSException alloc] initWithName:err.domain reason:err.localizedFailureReason userInfo:@{@"Error" : err}];
+        @throw exception;
+    }
+}
+
+- (nullable NSNumber *)evaluateConditionsWithAttributes:(NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
+    for (NSObject<OPTLYCondition> *condition in self.audienceConditions) {
+        NSNumber *result = [condition evaluateConditionsWithAttributes:attributes projectConfig:config];
+        if (result != NULL && [result boolValue] == true) {
+            // if user satisfies any conditions, return true.
+            return [NSNumber numberWithBool:true];
+        }
+    }
+    // if user doesn't satisfy any conditions, return false.
+    return [NSNumber numberWithBool:false];
 }
 
 - (void)setGroupId:(NSString *)groupId {

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.h
@@ -48,6 +48,34 @@ NS_ASSUME_NONNULL_BEGIN
  **/
 - (NSString *)getStringOrEmpty;
 
+/**
+ * Returns if object is of numeric type
+ *
+ * @returns A bool for whether object is valid numeric type.
+ **/
+- (BOOL)isNumeric;
+
+/**
+ * Returns if object is of boolean type
+ *
+ * @returns A bool for whether object is valid boolean type.
+ **/
+- (BOOL)isBool;
+
+/**
+ * Determines if object is a valid audience conditions array type.
+ *
+ * @returns A NSArray of audience conditions if valid, else return nil.
+ **/
+- (nullable NSArray *)getValidAudienceConditionsArray;
+
+/**
+ * Determines if object is a valid conditions array type.
+ *
+ * @returns A NSArray of conditions if valid, else return nil.
+ **/
+- (nullable NSArray *)getValidConditionsArray;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.m
@@ -15,6 +15,7 @@
  ***************************************************************************/
 
 #import "OPTLYNSObject+Validation.h"
+#import "OPTLYDatafileKeys.h"
 
 @implementation NSObject (Validation)
 
@@ -53,5 +54,79 @@
         }
     }
     return string;
+}
+
+-(BOOL)isNumeric {
+    //Check if given object is acceptable numeric type
+    if (self) {
+        if ([self isKindOfClass:[NSNumber class]]) {
+            NSNumber *number = (NSNumber*)self;
+            CFTypeID cfnumID = CFNumberGetTypeID(); // the type ID of CFNumber
+            CFTypeID numID = CFGetTypeID((__bridge CFTypeRef)(number)); // the type ID of num
+            if (numID == cfnumID) {
+                // Require real numbers (not infinite or NaN).
+                double doubleValue = [number doubleValue];
+                if (isfinite(doubleValue)) {
+                    return true;
+                }
+                else {
+                    return false;
+                }
+            }
+        }
+        return false;
+    }
+    return false;
+}
+
+-(BOOL)isBool {
+    //Check if given object is acceptable boolean type
+    if (self) {
+        if ([self isKindOfClass:[NSNumber class]]) {
+            NSNumber *number = (NSNumber*)self;
+            CFTypeID boolID = CFBooleanGetTypeID(); // the type ID of CFBoolean
+            CFTypeID numID = CFGetTypeID((__bridge CFTypeRef)(number)); // the type ID of num
+            return numID == boolID;
+        }
+    }
+    return false;
+}
+
+- (nullable NSArray *)getValidAudienceConditionsArray {
+    if(self) {
+        if ([self isKindOfClass:[NSString class]]) {
+            //Check if string is a valid json
+            NSError *error = nil;
+            NSData *data = [(NSString *)self dataUsingEncoding:NSUTF8StringEncoding];
+            id json = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:&error];
+            if (error) {
+                //check if string is not a valid json but is a non-empty string and can be casted as a number
+                if ([(NSString *)self getValidString]) {
+                    NSString *audienceString = [(NSString *)self getValidString];
+                    if ([audienceString intValue]) {
+                        return @[OPTLYDatafileKeysOrCondition,audienceString];
+                    }
+                }
+                return nil;
+            }
+            
+            return (NSArray *)json;
+        }
+    }
+    return nil;
+}
+
+- (nullable NSArray *)getValidConditionsArray {
+    if(self) {
+        if ([self isKindOfClass:[NSString class]]) {
+            NSError *error = nil;
+            NSData *data = [(NSString *)self dataUsingEncoding:NSUTF8StringEncoding];
+            NSArray *conditionsArray = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:&error];
+            if (!error) {
+                return conditionsArray;
+            }
+        }
+    }
+    return nil;
 }
 @end

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYAudienceTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYAudienceTest.m
@@ -34,9 +34,9 @@ static NSString * const kComplexAudience = @"[\"and\", [\"or\", [\"or\", {\"name
                                                                           @"conditions" : kAudienceConditions}
                                                                   error:nil];
     XCTAssertNotNil(audience);
-    XCTAssertTrue([[audience evaluateConditionsWithAttributes:@{@"browser_type" : @"android"}] boolValue]);
-    XCTAssertFalse([[audience evaluateConditionsWithAttributes:@{@"wrong_name" : @"android"}] boolValue]);
-    XCTAssertFalse([[audience evaluateConditionsWithAttributes:@{@"browser_type" : @"wrong_value"}] boolValue]);
+    XCTAssertTrue([[audience evaluateConditionsWithAttributes:@{@"browser_type" : @"android"} projectConfig:nil] boolValue]);
+    XCTAssertFalse([[audience evaluateConditionsWithAttributes:@{@"wrong_name" : @"android"} projectConfig:nil] boolValue]);
+    XCTAssertFalse([[audience evaluateConditionsWithAttributes:@{@"browser_type" : @"wrong_value"} projectConfig:nil] boolValue]);
 }
 
 - (void)testAudienceWithNotInitializedFromDictinoaryEvaluatesCorrectly {
@@ -46,9 +46,9 @@ static NSString * const kComplexAudience = @"[\"and\", [\"or\", [\"or\", {\"name
                                                                   error:nil];
     
     XCTAssertNotNil(audience);
-    XCTAssertTrue([[audience evaluateConditionsWithAttributes:@{@"example" : @"nottest"}] boolValue]);
-    XCTAssertFalse([[audience evaluateConditionsWithAttributes:@{@"example" : @"test"}] boolValue]);
-    XCTAssertFalse([[audience evaluateConditionsWithAttributes:@{@"wrong_name" : @"test"}] boolValue]);
+    XCTAssertTrue([[audience evaluateConditionsWithAttributes:@{@"example" : @"nottest"} projectConfig:nil] boolValue]);
+    XCTAssertFalse([[audience evaluateConditionsWithAttributes:@{@"example" : @"test"} projectConfig:nil] boolValue]);
+    XCTAssertFalse([[audience evaluateConditionsWithAttributes:@{@"wrong_name" : @"test"} projectConfig:nil] boolValue]);
 }
 
 - (void)testComplexAudience {
@@ -74,12 +74,12 @@ static NSString * const kComplexAudience = @"[\"and\", [\"or\", [\"or\", {\"name
     NSDictionary *attributesFailBadAttributeAnd = @{@"attribute_or" : @"attribute_or_value1",
                                                     @"attribute_not" : @"attribute_value"};
     
-    XCTAssertTrue([[audience evaluateConditionsWithAttributes:attributesPassOrValue1] boolValue]);
-    XCTAssertTrue([[audience evaluateConditionsWithAttributes:attributesPassOrValue2] boolValue]);
-    XCTAssertTrue([[audience evaluateConditionsWithAttributes:attributesPassOrValue3] boolValue]);
-    XCTAssertFalse([[audience evaluateConditionsWithAttributes:attributesFailBadAttributeNot] boolValue]);
-    XCTAssertFalse([[audience evaluateConditionsWithAttributes:attributesFailBadAttributeOr] boolValue]);
-    XCTAssertFalse([[audience evaluateConditionsWithAttributes:attributesFailBadAttributeAnd] boolValue]);
+    XCTAssertTrue([[audience evaluateConditionsWithAttributes:attributesPassOrValue1 projectConfig:nil] boolValue]);
+    XCTAssertTrue([[audience evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil] boolValue]);
+    XCTAssertTrue([[audience evaluateConditionsWithAttributes:attributesPassOrValue3 projectConfig:nil] boolValue]);
+    XCTAssertFalse([[audience evaluateConditionsWithAttributes:attributesFailBadAttributeNot projectConfig:nil] boolValue]);
+    XCTAssertFalse([[audience evaluateConditionsWithAttributes:attributesFailBadAttributeOr projectConfig:nil] boolValue]);
+    XCTAssertFalse([[audience evaluateConditionsWithAttributes:attributesFailBadAttributeAnd projectConfig:nil] boolValue]);
 }
 
 @end

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYDecisionServiceTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYDecisionServiceTest.m
@@ -31,8 +31,10 @@
 #import "OPTLYRollout.h"
 #import "OPTLYFeatureDecision.h"
 #import "OPTLYControlAttributes.h"
+#import "OPTLYLogger.h"
 
 static NSString * const kDatafileName = @"test_data_10_experiments";
+static NSString * const ktypeAudienceDatafileName = @"typed_audience_datafile";
 static NSString * const kUserId = @"6369992312";
 static NSString * const kUserNotInExperimentId = @"6358043286";
 
@@ -45,6 +47,10 @@ static NSString * const kWhitelistedVariation = @"a";
 static NSString * const kWhitelistedUserId_test_data_10_experiments = @"forced_variation_user";
 static NSString * const kWhitelistedExperiment_test_data_10_experiments = @"testExperiment6";
 static NSString * const kWhitelistedVariation_test_data_10_experiments = @"variation";
+
+// events with experiment and audiences
+static NSString * const kExperimentWithTypedAudienceKey = @"audience_combinations_experiment";
+static NSString * const kExperimentWithTypedAudienceId = @"3988293898";
 
 // events with experiment and audiences
 static NSString * const kExperimentWithAudienceKey = @"testExperimentWithFirefoxAudience";
@@ -62,8 +68,6 @@ static NSString * const kAttributeValueChrome = @"chrome";
 static NSString * const kAttributeKeyBrowserBuildNumberInt = @"browser_buildnumber";
 static NSString * const kAttributeKeyBrowserVersionNumberInt = @"browser_version";
 static NSString * const kAttributeKeyIsBetaVersionBool = @"browser_isbeta";
-
-
 
 // experiment with no audience
 static NSString * const kExperimentNoAudienceKey = @"testExperiment4";
@@ -96,9 +100,13 @@ static NSString * const kFeatureFlagNoBucketedRuleRolloutKey = @"booleanSingleVa
 
 @interface OPTLYDecisionServiceTest : XCTestCase
 @property (nonatomic, strong) Optimizely *optimizely;
+@property (nonatomic, strong) Optimizely *optimizelyTypedAudience;
 @property (nonatomic, strong) OPTLYProjectConfig *config;
 @property (nonatomic, strong) OPTLYDecisionService *decisionService;
 @property (nonatomic, strong) OPTLYBucketer *bucketer;
+@property (nonatomic, strong) OPTLYProjectConfig *typedAudienceConfig;
+@property (nonatomic, strong) OPTLYDecisionService *typedAudienceDecisionService;
+@property (nonatomic, strong) OPTLYBucketer *typedAudienceBucketer;
 @property (nonatomic, strong) NSDictionary *attributes;
 @property (nonatomic, strong) NSDictionary *userProfileWithFirefoxAudience;
 @end
@@ -116,8 +124,25 @@ static NSString * const kFeatureFlagNoBucketedRuleRolloutKey = @"booleanSingleVa
               variation:(nonnull OPTLYVariation *)variation
              experiment:(nonnull OPTLYExperiment *)experiment
                  userId:(nonnull NSString *)userId;
-@end
 
+- (BOOL)isUserInExperiment:(OPTLYProjectConfig *)config
+                experiment:(OPTLYExperiment *)experiment
+                attributes:(NSDictionary<NSString *, NSObject *> *)attributes;
+
+- (BOOL)shouldEvaluateUsingAudienceConditions:(OPTLYExperiment *)experiment;
+
+- (BOOL)evaluateAudienceConditionsForExperiment:(OPTLYExperiment *)experiment
+                                         config:(OPTLYProjectConfig *)config
+                                     attributes:(NSDictionary<NSString *, NSObject *> *)attributes;
+
+- (BOOL)evaluateAudienceIdsForExperiment:(OPTLYExperiment *)experiment
+                                  config:(OPTLYProjectConfig *)config
+                              attributes:(NSDictionary<NSString *, NSObject *> *)attributes;
+
+- (nullable NSNumber *)evaluateAudienceWithId:(NSString *)audienceId
+                                       config:(OPTLYProjectConfig *)config
+                                   attributes:(NSDictionary<NSString *, NSObject *> *)attributes;
+@end
 
 @implementation OPTLYDecisionServiceTest
 
@@ -126,6 +151,7 @@ static NSString * const kFeatureFlagNoBucketedRuleRolloutKey = @"booleanSingleVa
 - (void)setUp {
     [super setUp];
     NSData *datafile = [OPTLYTestHelper loadJSONDatafileIntoDataObject:kDatafileName];
+    NSData *typedAudienceDatafile = [OPTLYTestHelper loadJSONDatafileIntoDataObject:ktypeAudienceDatafileName];
 
     id<OPTLYUserProfileService> profileService = [OPTLYUserProfileServiceNoOp new];
 
@@ -133,9 +159,17 @@ static NSString * const kFeatureFlagNoBucketedRuleRolloutKey = @"booleanSingleVa
         builder.datafile = datafile;
         builder.userProfileService = profileService;
     }]];
+    self.optimizelyTypedAudience = [[Optimizely alloc] initWithBuilder:[OPTLYBuilder builderWithBlock:^(OPTLYBuilder * _Nullable builder) {
+        builder.datafile = typedAudienceDatafile;
+        builder.logger = [[OPTLYLoggerDefault alloc] initWithLogLevel:OptimizelyLogLevelOff];;
+    }]];
+    
     self.config = self.optimizely.config;
+    self.typedAudienceConfig = self.optimizelyTypedAudience.config;
     self.bucketer = [[OPTLYBucketer alloc] initWithConfig:self.config];
+    self.typedAudienceBucketer = [[OPTLYBucketer alloc] initWithConfig:self.typedAudienceConfig];
     self.decisionService = [[OPTLYDecisionService alloc] initWithProjectConfig:self.config bucketer:self.bucketer];
+    self.typedAudienceDecisionService = [[OPTLYDecisionService alloc] initWithProjectConfig:self.typedAudienceConfig bucketer:self.typedAudienceBucketer];
     self.attributes = @{ kAttributeKey : kAttributeValue };
     
     self.userProfileWithFirefoxAudience = @{ OPTLYDatafileKeysUserProfileServiceUserId : kUserId,
@@ -180,7 +214,7 @@ static NSString * const kFeatureFlagNoBucketedRuleRolloutKey = @"booleanSingleVa
                                                   attributes:badAttributes];
     NSAssert(isValid == false, @"Experiment running with user in experiment, but with bad attributes should fail validation.");
 }
-    
+
 - (void)testValidatePreconditionsAllowsWhiteListedUserToOverrideAudienceEvaluation {
     NSData *whitelistingDatafile = [OPTLYTestHelper loadJSONDatafileIntoDataObject:kWhitelistingTestDatafileName];
     Optimizely *optimizely = [[Optimizely alloc] initWithBuilder:[OPTLYBuilder builderWithBlock:^(OPTLYBuilder * _Nullable builder) {
@@ -199,6 +233,139 @@ static NSString * const kFeatureFlagNoBucketedRuleRolloutKey = @"booleanSingleVa
                            attributes:self.attributes];
     XCTAssertNotNil(variation);
     XCTAssertEqualObjects(variation.variationKey, kWhitelistedVariation);
+}
+
+- (void)testUserInExperimentWithEmptyAudienceIdAndConditions
+{
+    OPTLYExperiment *experiment = [self.typedAudienceConfig getExperimentForKey:kExperimentWithTypedAudienceKey];
+    experiment.audienceIds = @[];
+    experiment.audienceConditions = (NSArray<OPTLYCondition> *)@[];
+    BOOL isValid = [self.typedAudienceDecisionService isUserInExperiment:self.typedAudienceConfig experiment:experiment attributes:self.attributes];
+    
+    XCTAssertTrue(isValid);
+}
+
+- (void)testUserInExperimentWithValidAudienceIdAndEmptyAudienceConditions
+{
+    OPTLYExperiment *experiment = [self.typedAudienceConfig getExperimentForKey:kExperimentWithTypedAudienceKey];
+    experiment.audienceConditions = (NSArray<OPTLYCondition> *)@[];
+    BOOL isValid = [self.typedAudienceDecisionService isUserInExperiment:self.typedAudienceConfig experiment:experiment attributes:self.attributes];
+    XCTAssertTrue(isValid);
+}
+
+- (void)testUserInExperimentWithEmptyAudienceIdAndNilAudienceConditions
+{
+    OPTLYExperiment *experiment = [self.typedAudienceConfig getExperimentForKey:kExperimentWithTypedAudienceKey];
+    experiment.audienceIds = @[];
+    experiment.audienceConditions = nil;
+    BOOL isValid = [self.typedAudienceDecisionService isUserInExperiment:self.typedAudienceConfig experiment:experiment attributes:self.attributes];
+    XCTAssertTrue(isValid);
+}
+
+- (void)testIsUserInExperimentUsesNonNullAudienceConditionsWhenAudienceIdsAlsoAvailable
+{
+    OPTLYExperiment *experiment = [self.typedAudienceConfig getExperimentForKey:kExperimentWithTypedAudienceKey];
+    XCTAssertTrue([self.typedAudienceDecisionService shouldEvaluateUsingAudienceConditions:experiment]);
+}
+
+- (void)testIsUserInExperimentUsesAudienceIdsWhenAudienceConditionsNull
+{
+    OPTLYExperiment *experiment = [self.typedAudienceConfig getExperimentForKey:kExperimentWithTypedAudienceKey];
+    experiment.audienceConditions = nil;
+    XCTAssertFalse([self.typedAudienceDecisionService shouldEvaluateUsingAudienceConditions:experiment]);
+}
+
+- (void)testIsUserInExperimentReturnsTrueWhenBothAudienceConditionsAndAudienceIdsNull
+{
+    OPTLYExperiment *experiment = [self.typedAudienceConfig getExperimentForKey:kExperimentWithTypedAudienceKey];
+    experiment.audienceConditions = nil;
+    experiment.audienceIds = @[];
+    BOOL isValid = [self.typedAudienceDecisionService isUserInExperiment:self.typedAudienceConfig experiment:experiment attributes:self.attributes];
+    XCTAssertTrue(isValid);
+}
+
+- (void)testIsUserInExperimentEvaluatesAudienceWhenAttributesEmpty
+{
+    OPTLYExperiment *experiment = [self.typedAudienceConfig getExperimentForKey:kExperimentWithTypedAudienceKey];
+    id mock = [OCMockObject partialMockForObject:experiment];
+    [[mock expect] evaluateConditionsWithAttributes:[OCMArg any] projectConfig:[OCMArg any]];
+    [self.typedAudienceDecisionService isUserInExperiment:self.typedAudienceConfig experiment:experiment attributes:@{}];
+    XCTAssertTrue([mock verify]);
+    [mock stopMocking];
+}
+
+- (void)testIsUserInExperimentEvaluatesAudienceWhenAttributesEmptyAndAudienceConditionsNil
+{
+    OPTLYExperiment *experiment = [self.typedAudienceConfig getExperimentForKey:kExperimentWithTypedAudienceKey];
+    experiment.audienceConditions = nil;
+    OPTLYAudience *audience = [self.typedAudienceConfig getAudienceForId:experiment.audienceIds[0]];
+    id mock = [OCMockObject partialMockForObject:audience];
+    [[mock expect] evaluateConditionsWithAttributes:[OCMArg any] projectConfig:[OCMArg any]];
+    [self.typedAudienceDecisionService isUserInExperiment:self.typedAudienceConfig experiment:experiment attributes:@{}];
+    XCTAssertTrue([mock verify]);
+    [mock stopMocking];
+}
+
+- (void)testIsUserInExperimentEvaluatesAudienceWhenAttributesNil
+{
+    OPTLYExperiment *experiment = [self.typedAudienceConfig getExperimentForKey:kExperimentWithTypedAudienceKey];
+    id mock = [OCMockObject partialMockForObject:experiment];
+    [[mock expect] evaluateConditionsWithAttributes:[OCMArg any] projectConfig:[OCMArg any]];
+    [self.typedAudienceDecisionService isUserInExperiment:self.typedAudienceConfig experiment:experiment attributes:nil];
+    XCTAssertTrue([mock verify]);
+    [mock stopMocking];
+}
+
+- (void)testIsUserInExperimentEvaluatesAudienceWhenAttributesNilAndAudienceConditionsNil
+{
+    OPTLYExperiment *experiment = [self.typedAudienceConfig getExperimentForKey:kExperimentWithTypedAudienceKey];
+    experiment.audienceConditions = nil;
+    OPTLYAudience *audience = [self.typedAudienceConfig getAudienceForId:experiment.audienceIds[0]];
+    id mock = [OCMockObject partialMockForObject:audience];
+    [[mock expect] evaluateConditionsWithAttributes:[OCMArg any] projectConfig:[OCMArg any]];
+    [self.typedAudienceDecisionService isUserInExperiment:self.typedAudienceConfig experiment:experiment attributes:nil];
+    XCTAssertTrue([mock verify]);
+    [mock stopMocking];
+}
+
+- (void)testIsUserInExperimentReturnsFalseWhenEvaluatorReturnsFalseOrNull
+{
+    OPTLYExperiment *experiment = [self.typedAudienceConfig getExperimentForKey:kExperimentWithTypedAudienceKey];
+    id decisionServiceMock = OCMPartialMock(self.typedAudienceDecisionService);
+    OCMStub([decisionServiceMock evaluateAudienceConditionsForExperiment:[OCMArg any] config:[OCMArg any] attributes:[OCMArg any]]).andReturn(false);
+    BOOL isValid = [decisionServiceMock isUserInExperiment:self.typedAudienceConfig experiment:experiment attributes:self.attributes];
+    XCTAssertFalse(isValid);
+    [decisionServiceMock stopMocking];
+
+    decisionServiceMock = OCMPartialMock(self.typedAudienceDecisionService);
+    experiment.audienceConditions = nil;
+    OCMStub([decisionServiceMock evaluateAudienceIdsForExperiment:[OCMArg any] config:[OCMArg any] attributes:[OCMArg any]]).andReturn(false);
+    isValid = [decisionServiceMock isUserInExperiment:self.typedAudienceConfig experiment:experiment attributes:self.attributes];
+    XCTAssertFalse(isValid);
+    [decisionServiceMock stopMocking];
+    
+    decisionServiceMock = OCMPartialMock(self.typedAudienceDecisionService);
+    OCMStub([decisionServiceMock evaluateAudienceWithId:[OCMArg any] config:[OCMArg any] attributes:[OCMArg any]]).andReturn(nil);
+    isValid = [decisionServiceMock isUserInExperiment:self.typedAudienceConfig experiment:experiment attributes:self.attributes];
+    XCTAssertFalse(isValid);
+    [decisionServiceMock stopMocking];
+}
+
+- (void)testIsUserInExperimentReturnsTrueWhenEvaluatorReturnsTrue
+{
+    OPTLYExperiment *experiment = [self.typedAudienceConfig getExperimentForKey:kExperimentWithTypedAudienceKey];
+    id decisionServiceMock = OCMPartialMock(self.typedAudienceDecisionService);
+    OCMStub([decisionServiceMock evaluateAudienceConditionsForExperiment:[OCMArg any] config:[OCMArg any] attributes:[OCMArg any]]).andReturn(true);
+    BOOL isValid = [decisionServiceMock isUserInExperiment:self.typedAudienceConfig experiment:experiment attributes:self.attributes];
+    XCTAssertTrue(isValid);
+    [decisionServiceMock stopMocking];
+    
+    decisionServiceMock = OCMPartialMock(self.typedAudienceDecisionService);
+    experiment.audienceConditions = nil;
+    OCMStub([decisionServiceMock evaluateAudienceIdsForExperiment:[OCMArg any] config:[OCMArg any] attributes:[OCMArg any]]).andReturn(true);
+    isValid = [decisionServiceMock isUserInExperiment:self.typedAudienceConfig experiment:experiment attributes:self.attributes];
+    XCTAssertTrue(isValid);
+    [decisionServiceMock stopMocking];
 }
 
 #pragma mark - getVariation

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYProjectConfigTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYProjectConfigTest.m
@@ -351,12 +351,13 @@ static NSString * const kUnsupportedVersionDatafileName = @"UnsupportedVersionDa
                             }
                         ] forKey:@"attributes"];
     NSData *data = [NSJSONSerialization dataWithJSONObject:datafile options:0 error:NULL];
-    OPTLYProjectConfig *projectConfig = [OPTLYProjectConfig init:^(OPTLYProjectConfigBuilder * _Nullable builder){
+    
+    OPTLYProjectConfig *projectConfig = [[OPTLYProjectConfig alloc] initWithBuilder:[OPTLYProjectConfigBuilder builderWithBlock:^(OPTLYProjectConfigBuilder * _Nullable builder) {
         builder.datafile = data;
         builder.logger = [OPTLYLoggerDefault new];
         builder.errorHandler = [OPTLYErrorHandlerNoOp new];
         builder.userProfileService = [OPTLYUserProfileServiceNoOp new];
-    }];
+    }]];
     NSString *attributeId = [projectConfig getAttributeIdForKey:expectedAttributeKey];
     XCTAssertEqualObjects(attributeId, expectedAttributeId, @"should retrieve attribute Id %@ for reserved attribute key in datafile", expectedAttributeId);
 }

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYTypedAudienceTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYTypedAudienceTest.m
@@ -127,7 +127,7 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
                                              @"location" : @"San Francisco",
                                              @"browser" : @"Chrome"};
     
-    XCTAssertTrue([[audience evaluateConditionsWithAttributes:attributesPassOrValue] boolValue]);
+    XCTAssertTrue([[audience evaluateConditionsWithAttributes:attributesPassOrValue projectConfig:nil] boolValue]);
 }
 
 - (void)testEvaluateConditionsDoNotMatch {
@@ -140,7 +140,7 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
                                              @"location" : @"San Francisco",
                                              @"browser" : @"Firefox"};
     
-    XCTAssertFalse([[audience evaluateConditionsWithAttributes:attributesPassOrValue] boolValue]);
+    XCTAssertFalse([[audience evaluateConditionsWithAttributes:attributesPassOrValue projectConfig:nil] boolValue]);
 }
 
 - (void)testEvaluateEmptyUserAttributes {
@@ -151,7 +151,7 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
     XCTAssertNotNil(audience);
     NSDictionary *attributesPassOrValue = @{};
     
-    XCTAssertFalse([[audience evaluateConditionsWithAttributes:attributesPassOrValue] boolValue]);
+    XCTAssertFalse([[audience evaluateConditionsWithAttributes:attributesPassOrValue projectConfig:nil] boolValue]);
 }
 
 - (void)testEvaluateNullUserAttributes {
@@ -160,7 +160,7 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
                                                                           @"conditions" : kAudienceConditions}
                                                                   error:nil];
     XCTAssertNotNil(audience);
-    XCTAssertFalse([[audience evaluateConditionsWithAttributes:NULL] boolValue]);
+    XCTAssertFalse([[audience evaluateConditionsWithAttributes:NULL projectConfig:nil] boolValue]);
 }
 
 - (void)testTypedUserAttributesEvaluateTrue {
@@ -174,7 +174,7 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
                                              @"num_users" : @15,
                                              @"pi_value" : @3.14,
                                              @"decimal_value": @3.15678};
-    XCTAssertTrue([[audience evaluateConditionsWithAttributes:attributesPassOrValue] boolValue]);
+    XCTAssertTrue([[audience evaluateConditionsWithAttributes:attributesPassOrValue projectConfig:nil] boolValue]);
 }
 
 - (void)testEvaluateTrueWhenNoUserAttributesAndConditionEvaluatesTrue {
@@ -186,7 +186,7 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
                                                                           @"conditions" : conditions}
                                                                   error:nil];
     XCTAssertNotNil(audience);
-    XCTAssertTrue([[audience evaluateConditionsWithAttributes:NULL] boolValue]);
+    XCTAssertTrue([[audience evaluateConditionsWithAttributes:NULL projectConfig:nil] boolValue]);
 }
 
 
@@ -199,7 +199,7 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
                                              @"match": @"exact"};
     NSDictionary *attributesPassOrValue2 = @{@"device_type" : @"iPhone"};
     OPTLYBaseCondition *condition = [[OPTLYBaseCondition alloc] initWithDictionary:attributesPassOrValue1 error:nil];
-    XCTAssertNil([condition evaluateConditionsWithAttributes:attributesPassOrValue2]);
+    XCTAssertNil([condition evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil]);
 }
 
 - (void)testEvaluateReturnsNullWithInvalidMatchType {
@@ -209,7 +209,7 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
                                              @"match": @"invalid"};
     NSDictionary *attributesPassOrValue2 = @{@"device_type" : @"iPhone"};
     OPTLYBaseCondition *condition = [[OPTLYBaseCondition alloc] initWithDictionary:attributesPassOrValue1 error:nil];
-    XCTAssertNil([condition evaluateConditionsWithAttributes:attributesPassOrValue2]);
+    XCTAssertNil([condition evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil]);
 }
 
 - (void)testEvaluateReturnsNullWithInvalidValueForMatchType {
@@ -219,7 +219,7 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
                                              @"match": @"substring"};
     NSDictionary *attributesPassOrValue2 = @{@"is_firefox" : @false};
     OPTLYBaseCondition *condition = [[OPTLYBaseCondition alloc] initWithDictionary:attributesPassOrValue1 error:nil];
-    XCTAssertNil([condition evaluateConditionsWithAttributes:attributesPassOrValue2]);
+    XCTAssertNil([condition evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil]);
 }
 
 ///MARK:- ExactMatcher Tests
@@ -228,13 +228,13 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
     NSDictionary *attributesPassOrValue = @{};
     
     OPTLYAndCondition *andCondition1 = (OPTLYAndCondition *)[self getFirstConditionFromArray: [self kAudienceConditionsWithExactMatchStringType]];
-    XCTAssertNil([andCondition1 evaluateConditionsWithAttributes:attributesPassOrValue]);
+    XCTAssertNil([andCondition1 evaluateConditionsWithAttributes:attributesPassOrValue projectConfig:nil]);
     OPTLYAndCondition *andCondition2 = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithExactMatchBoolType]];
-    XCTAssertNil([andCondition2 evaluateConditionsWithAttributes:attributesPassOrValue]);
+    XCTAssertNil([andCondition2 evaluateConditionsWithAttributes:attributesPassOrValue projectConfig:nil]);
     OPTLYAndCondition *andCondition3 = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithExactMatchDecimalType]];
-    XCTAssertNil([andCondition3 evaluateConditionsWithAttributes:attributesPassOrValue]);
+    XCTAssertNil([andCondition3 evaluateConditionsWithAttributes:attributesPassOrValue projectConfig:nil]);
     OPTLYAndCondition *andCondition4 = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithExactMatchIntType]];
-    XCTAssertNil([andCondition4 evaluateConditionsWithAttributes:attributesPassOrValue]);
+    XCTAssertNil([andCondition4 evaluateConditionsWithAttributes:attributesPassOrValue projectConfig:nil]);
 }
 
 - (void)testExactMatcherReturnsFalseWhenAttributeValueDoesNotMatch {
@@ -244,13 +244,13 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
     NSDictionary *attributesPassOrValue4 = @{@"attr_value" : @55};
     
     OPTLYAndCondition *andCondition1 = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithExactMatchStringType]];
-    XCTAssertFalse([[andCondition1 evaluateConditionsWithAttributes:attributesPassOrValue1] boolValue]);
+    XCTAssertFalse([[andCondition1 evaluateConditionsWithAttributes:attributesPassOrValue1 projectConfig:nil] boolValue]);
     OPTLYAndCondition *andCondition2 = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithExactMatchBoolType]];
-    XCTAssertFalse([[andCondition2 evaluateConditionsWithAttributes:attributesPassOrValue2] boolValue]);
+    XCTAssertFalse([[andCondition2 evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil] boolValue]);
     OPTLYAndCondition *andCondition3 = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithExactMatchDecimalType]];
-    XCTAssertFalse([[andCondition3 evaluateConditionsWithAttributes:attributesPassOrValue3] boolValue]);
+    XCTAssertFalse([[andCondition3 evaluateConditionsWithAttributes:attributesPassOrValue3 projectConfig:nil] boolValue]);
     OPTLYAndCondition *andCondition4 = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithExactMatchIntType]];
-    XCTAssertFalse([[andCondition4 evaluateConditionsWithAttributes:attributesPassOrValue4] boolValue]);
+    XCTAssertFalse([[andCondition4 evaluateConditionsWithAttributes:attributesPassOrValue4 projectConfig:nil] boolValue]);
 }
 
 - (void)testExactMatcherReturnsNullWhenTypeMismatch {
@@ -261,14 +261,14 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
     NSDictionary *attributesPassOrValue5 = @{};
     
     OPTLYAndCondition *andCondition1 = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithExactMatchStringType]];
-    XCTAssertNil([andCondition1 evaluateConditionsWithAttributes:attributesPassOrValue1]);
-    XCTAssertNil([andCondition1 evaluateConditionsWithAttributes:attributesPassOrValue5]);
+    XCTAssertNil([andCondition1 evaluateConditionsWithAttributes:attributesPassOrValue1 projectConfig:nil]);
+    XCTAssertNil([andCondition1 evaluateConditionsWithAttributes:attributesPassOrValue5 projectConfig:nil]);
     OPTLYAndCondition *andCondition2 = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithExactMatchBoolType]];
-    XCTAssertNil([andCondition2 evaluateConditionsWithAttributes:attributesPassOrValue2]);
+    XCTAssertNil([andCondition2 evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil]);
     OPTLYAndCondition *andCondition3 = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithExactMatchDecimalType]];
-    XCTAssertNil([andCondition3 evaluateConditionsWithAttributes:attributesPassOrValue3]);
+    XCTAssertNil([andCondition3 evaluateConditionsWithAttributes:attributesPassOrValue3 projectConfig:nil]);
     OPTLYAndCondition *andCondition4 = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithExactMatchIntType]];
-    XCTAssertNil([andCondition4 evaluateConditionsWithAttributes:attributesPassOrValue4]);
+    XCTAssertNil([andCondition4 evaluateConditionsWithAttributes:attributesPassOrValue4 projectConfig:nil]);
 }
 
 - (void)testExactMatcherReturnsNullWithNumericInfinity {
@@ -276,9 +276,9 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
     NSDictionary *attributesPassOrValue2 = @{@"attr_value" : @15}; // Infinity condition
     
     OPTLYAndCondition *andCondition1 = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithExactMatchIntType]];
-    XCTAssertNil([andCondition1 evaluateConditionsWithAttributes:attributesPassOrValue1]);
+    XCTAssertNil([andCondition1 evaluateConditionsWithAttributes:attributesPassOrValue1 projectConfig:nil]);
     OPTLYAndCondition *andCondition2 = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kInfinityIntConditionStr]];
-    XCTAssertNil([andCondition2 evaluateConditionsWithAttributes:attributesPassOrValue2]);
+    XCTAssertNil([andCondition2 evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil]);
 }
 
 - (void)testExactMatcherReturnsTrueWhenAttributeValueMatches {
@@ -289,15 +289,15 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
     NSDictionary *attributesPassOrValue5 = @{@"attr_value" : @10.0};
     
     OPTLYAndCondition *andCondition1 = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithExactMatchStringType]];
-    XCTAssertTrue([[andCondition1 evaluateConditionsWithAttributes:attributesPassOrValue1] boolValue]);
+    XCTAssertTrue([[andCondition1 evaluateConditionsWithAttributes:attributesPassOrValue1 projectConfig:nil] boolValue]);
     OPTLYAndCondition *andCondition2 = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithExactMatchBoolType]];
-    XCTAssertTrue([[andCondition2 evaluateConditionsWithAttributes:attributesPassOrValue2] boolValue]);
+    XCTAssertTrue([[andCondition2 evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil] boolValue]);
     OPTLYAndCondition *andCondition3 = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithExactMatchDecimalType]];
-    XCTAssertTrue([[andCondition3 evaluateConditionsWithAttributes:attributesPassOrValue3] boolValue]);
+    XCTAssertTrue([[andCondition3 evaluateConditionsWithAttributes:attributesPassOrValue3 projectConfig:nil] boolValue]);
     OPTLYAndCondition *andCondition4 = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithExactMatchIntType]];
-    XCTAssertTrue([[andCondition4 evaluateConditionsWithAttributes:attributesPassOrValue4] boolValue]);
+    XCTAssertTrue([[andCondition4 evaluateConditionsWithAttributes:attributesPassOrValue4 projectConfig:nil] boolValue]);
     OPTLYAndCondition *andCondition5 = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithExactMatchIntType]];
-    XCTAssertTrue([[andCondition5 evaluateConditionsWithAttributes:attributesPassOrValue5] boolValue]);
+    XCTAssertTrue([[andCondition5 evaluateConditionsWithAttributes:attributesPassOrValue5 projectConfig:nil] boolValue]);
 }
 
 ///MARK:- ExistsMatcher Tests
@@ -305,13 +305,13 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
 - (void)testExistsMatcherReturnsFalseWhenAttributeIsNotProvided {
     NSDictionary *attributesPassOrValue = @{};
     OPTLYAndCondition *andCondition = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithExistsMatchType]];
-    XCTAssertFalse([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue] boolValue]);
+    XCTAssertFalse([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue projectConfig:nil] boolValue]);
 }
 
 - (void)testExistsMatcherReturnsFalseWhenAttributeIsNull {
     NSDictionary *attributesPassOrValue = @{@"attr_value" : [NSNull null]};
     OPTLYAndCondition *andCondition = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithExistsMatchType]];
-    XCTAssertFalse([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue] boolValue]);
+    XCTAssertFalse([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue projectConfig:nil] boolValue]);
 }
 
 - (void)testExistsMatcherReturnsTrueWhenAttributeValueIsProvided {
@@ -322,11 +322,11 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
     NSDictionary *attributesPassOrValue5 = @{@"attr_value" : @false};
     
     OPTLYAndCondition *andCondition = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithExistsMatchType]];
-    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue1] boolValue]);
-    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue2] boolValue]);
-    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue3] boolValue]);
-    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue4] boolValue]);
-    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue5] boolValue]);
+    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue1 projectConfig:nil] boolValue]);
+    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil] boolValue]);
+    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue3 projectConfig:nil] boolValue]);
+    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue4 projectConfig:nil] boolValue]);
+    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue5 projectConfig:nil] boolValue]);
 }
 
 ///MARK:- SubstringMatcher Tests
@@ -334,7 +334,7 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
 - (void)testSubstringMatcherReturnsFalseWhenConditionValueIsNotSubstringOfUserValue {
     NSDictionary *attributesPassOrValue = @{@"attr_value":@"Breaking news!"};
     OPTLYAndCondition *andCondition = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithSubstringMatchType]];
-    XCTAssertFalse([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue] boolValue]);
+    XCTAssertFalse([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue projectConfig:nil] boolValue]);
 }
 
 - (void)testSubstringMatcherReturnsTrueWhenConditionValueIsSubstringOfUserValue {
@@ -342,8 +342,8 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
     NSDictionary *attributesPassOrValue2 = @{@"attr_value" : @"chrome vs firefox"};
     
     OPTLYAndCondition *andCondition = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithSubstringMatchType]];
-    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue1] boolValue]);
-    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue2] boolValue]);
+    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue1 projectConfig:nil] boolValue]);
+    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil] boolValue]);
 }
 
 - (void)testSubstringMatcherReturnsNullWhenAttributeValueIsNotAString {
@@ -352,15 +352,16 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
     NSDictionary *attributesPassOrValue3 = @{};
     
     OPTLYAndCondition *andCondition = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithSubstringMatchType]];
-    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue1]);
-    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue2]);
-    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue3]);
+    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue1 projectConfig:nil]);
+    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil]);
+    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue3 projectConfig:nil]);
 }
 
 - (void)testSubstringMatcherReturnsNullWhenAttributeIsNotProvided{
     NSDictionary *attributesPassOrValue = @{};
+
     OPTLYAndCondition *andCondition = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithSubstringMatchType]];
-    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue]);
+    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue projectConfig:nil]);
 }
 
 ///MARK:- GTMatcher Tests
@@ -371,9 +372,9 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
     NSDictionary *attributesPassOrValue3 = @{@"attr_value" : @10.0};
     
     OPTLYAndCondition *andCondition = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithGreaterThanMatchType]];
-    XCTAssertFalse([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue1] boolValue]);
-    XCTAssertFalse([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue2] boolValue]);
-    XCTAssertFalse([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue3] boolValue]);
+    XCTAssertFalse([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue1 projectConfig:nil] boolValue]);
+    XCTAssertFalse([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil] boolValue]);
+    XCTAssertFalse([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue3 projectConfig:nil] boolValue]);
 }
 
 - (void)testGTMatcherReturnsNullWhenAttributeValueIsNotANumericValue {
@@ -383,16 +384,16 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
     NSDictionary *attributesPassOrValue4 = @{@"attr_value" : @NO};
     
     OPTLYAndCondition *andCondition = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithGreaterThanMatchType]];
-    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue1]);
-    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue2]);
-    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue3]);
-    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue4]);
+    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue1 projectConfig:nil]);
+    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil]);
+    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue3 projectConfig:nil]);
+    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue4 projectConfig:nil]);
 }
 
 - (void)testGTMatcherReturnsNullWhenAttributeValueIsInfinity {
     NSDictionary *attributesPassOrValue = @{@"attr_value" : [NSNumber numberWithFloat:INFINITY]};
     OPTLYAndCondition *andCondition = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithGreaterThanMatchType]];
-    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue]);
+    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue projectConfig:nil]);
 }
 
 - (void)testGTMatcherReturnsTrueWhenAttributeValueIsGreaterThanConditionValue {
@@ -400,8 +401,8 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
     NSDictionary *attributesPassOrValue2 = @{@"attr_value" : @10.1};
     
     OPTLYAndCondition *andCondition = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithGreaterThanMatchType]];
-    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue1] boolValue]);
-    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue2] boolValue]);
+    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue1 projectConfig:nil] boolValue]);
+    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil] boolValue]);
 }
 
 ///MARK:- LTMatcher Tests
@@ -411,8 +412,8 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
     NSDictionary *attributesPassOrValue2 = @{@"attr_value" : @10};
     
     OPTLYAndCondition *andCondition = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithLessThanMatchType]];
-    XCTAssertFalse([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue1] boolValue]);
-    XCTAssertFalse([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue2] boolValue]);
+    XCTAssertFalse([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue1 projectConfig:nil] boolValue]);
+    XCTAssertFalse([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil] boolValue]);
 }
 
 - (void)testLTMatcherReturnsNullWhenAttributeValueIsNotANumericValue {
@@ -420,14 +421,14 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
     NSDictionary *attributesPassOrValue2 = @{};
     
     OPTLYAndCondition *andCondition = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithLessThanMatchType]];
-    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue1]);
-    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue2]);
+    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue1 projectConfig:nil]);
+    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil]);
 }
 
 - (void)testLTMatcherReturnsNullWhenAttributeValueIsInfinity {
     NSDictionary *attributesPassOrValue = @{@"attr_value" : [NSNumber numberWithFloat:INFINITY]};
     OPTLYAndCondition *andCondition = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithLessThanMatchType]];
-    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue]);
+    XCTAssertNil([andCondition evaluateConditionsWithAttributes:attributesPassOrValue projectConfig:nil]);
 }
 
 - (void)testLTMatcherReturnsTrueWhenAttributeValueIsLessThanConditionValue {
@@ -435,8 +436,8 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
     NSDictionary *attributesPassOrValue2 = @{@"attr_value" : @9.9};
     
     OPTLYAndCondition *andCondition = (OPTLYAndCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithLessThanMatchType]];
-    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue1] boolValue]);
-    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue2] boolValue]);
+    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue1 projectConfig:nil] boolValue]);
+    XCTAssertTrue([[andCondition evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil] boolValue]);
 }
 
 ///MARK:- Helper Methods

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
@@ -31,6 +31,8 @@
 #import "OPTLYFeatureVariable.h"
 #import "OPTLYNotificationCenter.h"
 #import "OPTLYEventMetric.h"
+#import "OPTLYEventParameterKeys.h"
+#import "OPTLYEventBuilder.h"
 
 static NSString *const kUserId = @"userId";
 static NSString *const kExperimentKey = @"testExperimentWithFirefoxAudience";
@@ -86,6 +88,9 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
                                  variableKey:(nullable NSString *)variableKey
                                       userId:(nullable NSString *)userId
                                   attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes;
+@end
+
+@interface OPTLYEventBuilderDefault(Tests)
 @end
 
 @interface OptimizelyTest : XCTestCase
@@ -331,7 +336,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     }];
     
     OPTLYVariation *_variation = [self.optimizely activate:kExperimentKeyForWhitelisting
-                                                   userId:kUserId];
+                                                    userId:kUserId];
     XCTAssertNotNil(_variation);
     XCTAssertEqual(experiment.experimentId, notificationExperimentKey);
 }
@@ -342,10 +347,10 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     __block NSString *notificationExperimentKey = nil;
     
     NSDictionary<NSString *, NSObject *> *expectedAttributes = @{
-                                                         @"browser_name": @"chrome",
-                                                         @"buildno": @(10),
-                                                         @"buildversion": @(0.13)
-                                                         };
+                                                                 @"browser_name": @"chrome",
+                                                                 @"buildno": @(10),
+                                                                 @"buildversion": @(0.13)
+                                                                 };
     __block NSDictionary<NSString *, NSObject *> *actualAttributes;
     
     [self.optimizely.notificationCenter addActivateNotificationListener:^(OPTLYExperiment *experiment, NSString *userId, NSDictionary<NSString *, NSObject *> *attributes, OPTLYVariation *variation, NSDictionary<NSString *,NSString *> *event) {
@@ -463,11 +468,11 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     __block NSDictionary<NSString *, NSObject *> *actualEventTags;
     
     NSDictionary<NSString *, NSObject *> *expectedEventTags = @{
-                                                         OPTLYEventMetricNameRevenue: OPTLYEventMetricNameValue,
-                                                         @"event_int": @(11),
-                                                         @"event_version": @(1.3),
-                                                         @"event_bool": @(YES)
-                                                         };
+                                                                OPTLYEventMetricNameRevenue: OPTLYEventMetricNameValue,
+                                                                @"event_int": @(11),
+                                                                @"event_version": @(1.3),
+                                                                @"event_bool": @(YES)
+                                                                };
     
     [self.optimizely.notificationCenter addTrackNotificationListener:^(NSString * _Nonnull eventKey, NSString * _Nonnull userId, NSDictionary<NSString *, NSObject *> * _Nonnull attributes, NSDictionary * _Nonnull eventTags, NSDictionary<NSString *,NSObject *> * _Nonnull event) {
         actualAttributes = attributes;
@@ -635,7 +640,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     
     // SendImpressionEvent() does get called.
     OCMVerify([optimizelyMock sendImpressionEventFor:decision.experiment variation:decision.variation userId:kUserId attributes:nil callback:nil]);
-
+    
     OCMVerify([decisionServiceMock getVariationForFeature:featureFlag userId:kUserId attributes:nil]);
     [decisionServiceMock stopMocking];
 }
@@ -782,7 +787,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     NSString *featureKey = @"featureKey";
     NSString *variableKeyDouble = @"varDouble";
     NSString *featureVariableType = FeatureVariableTypeDouble;
-
+    
     // expectations
     NSString *expectedValueString = @"100.54";
     double expectedValue = 100.54;
@@ -801,7 +806,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     NSString *featureKey = @"featureKey";
     NSString *variableKeyInt = @"varInt";
     NSString *featureVariableType = FeatureVariableTypeDouble;
-
+    
     NSString *expectedValueString = @"100";
     double expectedValue = 100;
     id optimizelyMock = [self getOptimizelyMockForFeatureVariableType:featureVariableType variableKey:variableKeyInt expectedReturn:expectedValueString];
@@ -819,7 +824,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     NSString *featureKey = @"featureKey";
     NSString *variableKeyNonDouble = @"varNonDouble";
     NSString *featureVariableType = FeatureVariableTypeDouble;
-
+    
     NSString *expectedValueString = @"nonDoubleValue";
     double expectedValue = 0.0;
     id optimizelyMock = [self getOptimizelyMockForFeatureVariableType:featureVariableType variableKey:variableKeyNonDouble expectedReturn:expectedValueString];
@@ -837,7 +842,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     NSString *featureKey = @"featureKey";
     NSString *variableKeyNull = @"varNull";
     NSString *featureVariableType = FeatureVariableTypeDouble;
-
+    
     NSString *expectedValueString = nil;
     NSNumber* expectedValue = nil;
     id optimizelyMock = [self getOptimizelyMockForFeatureVariableType:featureVariableType variableKey:variableKeyNull expectedReturn:expectedValueString];
@@ -991,10 +996,10 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     
     // Passing nil and empty feature key.
     XCTAssertNil([self.optimizely getFeatureVariableValueForType:variableType
-                                                     featureKey:nil
-                                                    variableKey:variableKey
-                                                         userId:kUserId
-                                                     attributes:nil]);
+                                                      featureKey:nil
+                                                     variableKey:variableKey
+                                                          userId:kUserId
+                                                      attributes:nil]);
     XCTAssertNil([self.optimizely getFeatureVariableValueForType:variableType
                                                       featureKey:@""
                                                      variableKey:variableKey
@@ -1090,10 +1095,10 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     OCMStub([decisionServiceMock getVariationForFeature:featureFlag userId:kUserId attributes:nil]).andReturn(nil);
     
     NSString *value = [self.optimizely getFeatureVariableValueForType:variableType
-                                                                   featureKey:featureKey
-                                                                  variableKey:variableKey
-                                                                       userId:kUserId
-                                                                   attributes:nil];
+                                                           featureKey:featureKey
+                                                          variableKey:variableKey
+                                                               userId:kUserId
+                                                           attributes:nil];
     XCTAssertEqualObjects(expectedValue, value, @"should return %@ for featureFlag not enabled", expectedValue);
     
     OCMVerify([decisionServiceMock getVariationForFeature:featureFlag userId:kUserId attributes:nil]);
@@ -1161,20 +1166,20 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     OPTLYExperiment *experiment = [self.optimizely.config getExperimentForKey:@"177770"];
     OPTLYVariation *variation = [experiment getVariationForVariationId:@"177771"];
     OPTLYFeatureDecision *expectedDecision = [[OPTLYFeatureDecision alloc] initWithExperiment:experiment variation:variation source:DecisionSourceRollout];
-        
+    
     id decisionServiceMock = OCMPartialMock(self.optimizely.decisionService);
     OCMStub([decisionServiceMock getVariationForFeature:featureFlag userId:kUserId attributes:nil]).andReturn(expectedDecision);
-                                   
-   BOOL value = [self.optimizely getFeatureVariableBoolean:featureKey
+    
+    BOOL value = [self.optimizely getFeatureVariableBoolean:featureKey
                                                 variableKey:variableKey
                                                      userId:kUserId
                                                  attributes:nil];
-   XCTAssertEqual(expectedVariableValue, value, @"should return %@ for featureFlag enabled but dont used", expectedVariableValue ? @"true" : @"false");
-                                   
-   OCMVerify([decisionServiceMock getVariationForFeature:featureFlag userId:kUserId attributes:nil]);
-   [decisionServiceMock stopMocking];
-}
+    XCTAssertEqual(expectedVariableValue, value, @"should return %@ for featureFlag enabled but dont used", expectedVariableValue ? @"true" : @"false");
     
+    OCMVerify([decisionServiceMock getVariationForFeature:featureFlag userId:kUserId attributes:nil]);
+    [decisionServiceMock stopMocking];
+}
+
 #pragma mark - GetEnabledFeatures Tests
 
 // should return empty feature array as no feature is enabled for user
@@ -1185,7 +1190,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     OCMVerify([optimizelyMock isFeatureEnabled:[OCMArg any] userId:kUserId attributes:self.attributes]);
     [optimizelyMock stopMocking];
 }
-    
+
 // should return feature array as some feature is enabled for user
 -(void)testGetEnabledFeaturesWithSomeFeaturesEnabledForUser {
     NSArray<NSString *> *enabledFeatures = @[@"booleanFeature", @"booleanSingleVariableFeature", @"multiVariateFeature"];
@@ -1195,7 +1200,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 
 #pragma mark - TypedAudiences Tests
 
-- (void)testActivateWithTypedAudiences {
+- (void)testActivateWithTypedAudiencesWithExactMatchType {
     // Should be included via exact match string audience with id '3468206642'
     NSDictionary<NSString *, NSObject *> *expectedAttributes = @{
                                                                  @"house": @"Gryffindor"
@@ -1234,59 +1239,68 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     [expectation fulfill];
     
     [self waitForExpectationsWithTimeout:2 handler:nil];
-    
+}
+
+- (void)testActivateWithTypedAudiencesWithSubstringMatchType {
     // Should be included via substring match string audience with id '3988293898'
-    expectedAttributes = @{
-                           @"house": @"222Slytherin"
-                           };
-    expectation = [self expectationWithDescription:@"getActivatedVariation"];
-    
-    variation = [self.optimizelyTypedAudience activate:@"typed_audience_experiment" userId:@"user1" attributes:expectedAttributes callback:^(NSError *error) {
-    }];
-    XCTAssertEqualObjects(@"A", variation.variationKey);
-    [expectation fulfill];
-    
-    [self waitForExpectationsWithTimeout:2 handler:nil];
-    
-    // Should be included via exists match string audience with id '3988293899'
-    expectedAttributes = @{
-                           @"favorite_ice_cream": @1
-                           };
-    expectation = [self expectationWithDescription:@"getActivatedVariation"];
-    
-    variation = [self.optimizelyTypedAudience activate:@"typed_audience_experiment" userId:@"user1" attributes:expectedAttributes callback:^(NSError *error) {
-    }];
-    XCTAssertEqualObjects(@"A", variation.variationKey);
-    [expectation fulfill];
-    
-    [self waitForExpectationsWithTimeout:2 handler:nil];
-    
-    // Should be included via lt match number audience with id '3468206644'
-    expectedAttributes = @{
-                                                                 @"lasers": @0.8
+    NSDictionary<NSString *, NSObject *> *expectedAttributes = @{
+                                                                 @"house": @"222Slytherin"
                                                                  };
-    expectation = [self expectationWithDescription:@"getActivatedVariation"];
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"getActivatedVariation"];
     
-    variation = [self.optimizelyTypedAudience activate:@"typed_audience_experiment" userId:@"user1" attributes:expectedAttributes callback:^(NSError *error) {
-    }];
-    XCTAssertEqualObjects(@"A", variation.variationKey);
-    [expectation fulfill];
-    
-    [self waitForExpectationsWithTimeout:2 handler:nil];
-    
-    // Should be included via gt match number audience with id '3468206647'
-    expectedAttributes = @{
-                           @"lasers": @71
-                           };
-    expectation = [self expectationWithDescription:@"getActivatedVariation"];
-    
-    variation = [self.optimizelyTypedAudience activate:@"typed_audience_experiment" userId:@"user1" attributes:expectedAttributes callback:^(NSError *error) {
+    OPTLYVariation *variation = [self.optimizelyTypedAudience activate:@"typed_audience_experiment" userId:@"user1" attributes:expectedAttributes callback:^(NSError *error) {
     }];
     XCTAssertEqualObjects(@"A", variation.variationKey);
     [expectation fulfill];
     
     [self waitForExpectationsWithTimeout:2 handler:nil];
 }
+
+- (void)testActivateWithTypedAudiencesWithExistsMatchType {
+    // Should be included via exists match string audience with id '3988293899'
+    NSDictionary<NSString *, NSObject *> *expectedAttributes = @{
+                                                                 @"favorite_ice_cream": @1
+                                                                 };
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"getActivatedVariation"];
+    
+    OPTLYVariation *variation = [self.optimizelyTypedAudience activate:@"typed_audience_experiment" userId:@"user1" attributes:expectedAttributes callback:^(NSError *error) {
+    }];
+    XCTAssertEqualObjects(@"A", variation.variationKey);
+    [expectation fulfill];
+    
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+- (void)testActivateWithTypedAudiencesWithLtMatchType {
+    // Should be included via lt match number audience with id '3468206644'
+    NSDictionary<NSString *, NSObject *> *expectedAttributes = @{
+                                                                 @"lasers": @0.8
+                                                                 };
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"getActivatedVariation"];
+    
+    OPTLYVariation *variation = [self.optimizelyTypedAudience activate:@"typed_audience_experiment" userId:@"user1" attributes:expectedAttributes callback:^(NSError *error) {
+    }];
+    XCTAssertEqualObjects(@"A", variation.variationKey);
+    [expectation fulfill];
+    
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+- (void)testActivateWithTypedAudiencesWithGtMatchType {
+    // Should be included via gt match number audience with id '3468206647'
+    NSDictionary<NSString *, NSObject *> *expectedAttributes = @{
+                                                                 @"lasers": @71
+                                                                 };
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"getActivatedVariation"];
+    
+    OPTLYVariation *variation = [self.optimizelyTypedAudience activate:@"typed_audience_experiment" userId:@"user1" attributes:expectedAttributes callback:^(NSError *error) {
+    }];
+    XCTAssertEqualObjects(@"A", variation.variationKey);
+    [expectation fulfill];
+    
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
 
 - (void)testActivateExcludesUserFromExperimentWithTypedAudiences {
     NSDictionary<NSString *, NSObject *> *expectedAttributes = @{
@@ -1389,6 +1403,166 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     XCTAssertEqualObjects(featureVariable, @"x");
 }
 
+#pragma mark - Audience Combination Tests
+
+//Test that activate calls dispatch_event with right params and returns expected
+//variation when attributes are provided and complex audience conditions are met.
+- (void)testActivateWithAttributesComplexAudienceMatch {
+    
+    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+                                                             @"house": @"Welcome to Slytherin!",
+                                                             @"lasers": @45.5
+                                                             };
+    NSDictionary<NSString *, NSObject *> *expectedAttributes1 = @{
+                                                                  @"shouldIndex": @1,
+                                                                  @"type": @"custom",
+                                                                  @"value": @45.5,
+                                                                  @"entity_id": @"594016",
+                                                                  @"key": @"lasers"
+                                                                  };
+    NSDictionary<NSString *, NSObject *> *expectedAttributes2 = @{
+                                                                  @"shouldIndex": @1,
+                                                                  @"type": @"custom",
+                                                                  @"value": @"Welcome to Slytherin!",
+                                                                  @"entity_id": @"594015",
+                                                                  @"key": @"house"
+                                                                  };
+    
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"getActivatedVariation"];
+    
+    __weak id weakSelf = self;
+    [self.optimizelyTypedAudience.notificationCenter addActivateNotificationListener:^(OPTLYExperiment *experiment, NSString *userId, NSDictionary<NSString *, NSObject *> *attributes, OPTLYVariation *variation, NSDictionary<NSString *,NSString *> *event) {
+        id self = weakSelf;
+        NSDictionary *visitors = [(NSArray *)event[@"visitors"] firstObject];
+        NSArray *_attributes = (NSArray *)visitors[@"attributes"];
+        XCTAssertTrue([_attributes containsObject:expectedAttributes1]);
+        XCTAssertTrue([_attributes containsObject:expectedAttributes2]);
+        [expectation fulfill];
+    }];
+    
+    OPTLYVariation *variation = [self.optimizelyTypedAudience activate:@"audience_combinations_experiment" userId:@"test_user" attributes:userAttributes callback:^(NSError *error) {
+    }];
+    XCTAssertEqualObjects(@"A", variation.variationKey);
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+//Test that activate returns None when complex audience conditions do not match.
+- (void)testActivateWithAttributesComplexAudienceMismatch {
+    
+    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+                                                             @"house": @"Hufflepuff",
+                                                             @"lasers": @45.5
+                                                             };
+    
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"getActivatedVariation"];
+    OPTLYExperiment *experiment = [self.optimizelyTypedAudience.config getExperimentForKey:@"audience_combinations_experiment"];
+    OPTLYVariation *variation = [self.optimizelyTypedAudience variation:@"audience_combinations_experiment" userId:@"test_user" attributes:self.attributes];
+    id optimizelyMock = OCMPartialMock(self.optimizelyTypedAudience);
+    
+    OPTLYVariation *_variation = [self.optimizelyTypedAudience activate:@"audience_combinations_experiment" userId:@"test_user" attributes:userAttributes callback:^(NSError *error) {
+        [expectation fulfill];
+    }];
+    
+    // SendImpressionEvent() does not get called.
+    OCMReject([optimizelyMock sendImpressionEventFor:experiment variation:variation userId:@"test_user" attributes:userAttributes callback:[OCMArg any]]);
+    [optimizelyMock stopMocking];
+    
+    XCTAssertNil(_variation);
+    [self waitForExpectationsWithTimeout:2 handler:nil];
+}
+
+//Test that track calls Notification Listener with right params when attributes are provided
+//and it's a complex audience match.
+- (void)testTrackWithAttributesComplexAudienceMatch {
+    
+    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+                                                             @"house": @"Gryffindor",
+                                                             @"should_do_it": @YES
+                                                             };
+    NSDictionary<NSString *, NSObject *> *expectedAttributes1 = @{
+                                                                  @"shouldIndex": @1,
+                                                                  @"type": @"custom",
+                                                                  @"value": @"Gryffindor",
+                                                                  @"entity_id": @"594015",
+                                                                  @"key": @"house"
+                                                                  };
+    NSDictionary<NSString *, NSObject *> *expectedAttributes2 = @{
+                                                                  @"shouldIndex": @1,
+                                                                  @"type": @"custom",
+                                                                  @"value": @YES,
+                                                                  @"entity_id": @"594017",
+                                                                  @"key": @"should_do_it"
+                                                                  };
+    __weak XCTestExpectation *expectation = [self expectationWithDescription:@"trackedSuccessfuly"];
+    id loggerMock = OCMPartialMock((OPTLYLoggerDefault *)self.optimizelyTypedAudience.logger);
+    
+    __weak id weakSelf = self;
+    [self.optimizelyTypedAudience.notificationCenter addTrackNotificationListener:^(NSString * _Nonnull eventKey, NSString * _Nonnull userId, NSDictionary<NSString *, NSObject *> * _Nonnull attributes, NSDictionary * _Nonnull eventTags, NSDictionary<NSString *,NSObject *> * _Nonnull event) {
+        id self = weakSelf;
+        NSDictionary *visitors = [(NSArray *)event[@"visitors"] firstObject];
+        NSArray *_attributes = (NSArray *)visitors[@"attributes"];
+        XCTAssertTrue([_attributes containsObject:expectedAttributes1]);
+        XCTAssertTrue([_attributes containsObject:expectedAttributes2]);
+        [expectation fulfill];
+    }];
+    
+    [self.optimizelyTypedAudience track:@"user_signed_up" userId:@"test_user" attributes:userAttributes];
+    NSString *logMessage = [NSString stringWithFormat:OPTLYLoggerMessagesEventDispatcherAttemptingToSendConversionEvent, @"user_signed_up", @"test_user"];
+    OCMVerify([loggerMock logMessage:logMessage withLevel:OptimizelyLogLevelInfo]);
+    [loggerMock stopMocking];
+    
+    [self waitForExpectationsWithTimeout:5 handler:nil];
+}
+
+//Test that track does not call dispatch_event when complex audience conditions do not match.
+- (void)testTrackWithAttributesComplexAudienceMismatch {
+    
+    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+                                                             @"house": @"Gryffindor",
+                                                             @"should_do_it": @false
+                                                             };
+    
+    id loggerMock = OCMPartialMock((OPTLYLoggerDefault *)self.optimizelyTypedAudience.logger);
+    
+    [self.optimizelyTypedAudience track:@"user_signed_up" userId:@"test_user" attributes:userAttributes];
+    NSString *logMessage = [NSString stringWithFormat:OPTLYLoggerMessagesConversionFailure, @"user_signed_up"];
+    OCMVerify([loggerMock logMessage:logMessage withLevel:OptimizelyLogLevelInfo]);
+    [loggerMock stopMocking];
+}
+
+//Test that isFeatureEnabled returns True for feature rollout with complex audience match.
+- (void)testIsFeatureEnabledInRolloutComplexAudienceMatch {
+    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+                                                             @"house": @"...Slytherinnn...sss.",
+                                                             @"favorite_ice_cream": @"matcha"
+                                                             };
+    NSString *featureFlagKey = @"feat2";
+    XCTAssertTrue([self.optimizelyTypedAudience isFeatureEnabled:featureFlagKey userId:@"test_user" attributes:userAttributes]);
+}
+
+//Test that isFeatureEnabled returns False for feature rollout with complex audience mismatch.
+- (void)testIsFeatureEnabledInRolloutComplexAudienceMismatch {
+    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+                                                             @"house": @"Lannister"
+                                                             };
+    NSString *featureFlagKey = @"feat2";
+    XCTAssertFalse([self.optimizelyTypedAudience isFeatureEnabled:featureFlagKey userId:@"test_user" attributes:userAttributes]);
+}
+
+//Test that getFeatureVariableInteger return variable value with complex audience match.
+- (void)testGetFeatureVariableReturnsVariableValueComplexAudienceMatch {
+    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+                                                             @"house": @"Gryffindor",
+                                                             @"lasers": @700
+                                                             };
+    XCTAssertEqual([[self.optimizelyTypedAudience getFeatureVariableInteger:@"feat2_with_var" variableKey:@"z" userId:@"user1" attributes:userAttributes] integerValue], 150);
+}
+
+//Test that getFeatureVariableInteger return default value with complex audience mismatch.
+- (void)testGetFeatureVariableReturnsDefaultValueComplexAudienceMatch {
+    XCTAssertEqual([[self.optimizelyTypedAudience getFeatureVariableInteger:@"feat2_with_var" variableKey:@"z" userId:@"user1" attributes:@{}] integerValue], 10);
+}
+
 #pragma mark - Helper Methods
 
 - (id)getOptimizelyMockForFeatureVariableType:(NSString *)featureVariableType variableKey:(NSString *)variableKey expectedReturn:(NSString *)expectedReturn {
@@ -1424,3 +1598,4 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 }
 
 @end
+

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/TestData/typed_audience_datafile.json
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/TestData/typed_audience_datafile.json
@@ -1,43 +1,4 @@
 {
-    "experiments": [{
-        "status": "Running",
-        "key": "feat_with_var_test",
-        "layerId": "11504144555",
-        "trafficAllocation": [{
-            "entityId": "11617170975",
-            "endOfRange": 10000
-        }],
-        "audienceIds": ["3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"],
-        "variations": [{
-            "variables": [{
-                "id": "11535264366",
-                "value": "xyz"
-            }],
-            "id": "11617170975",
-            "key": "variation_2",
-            "featureEnabled": true
-        }],
-        "forcedVariations": {},
-        "id": "11564051718"
-    },
-    {
-        "id": "1323241597",
-        "key": "typed_audience_experiment",
-        "layerId": "1630555627",
-        "status": "Running",
-        "variations": [{
-            "id": "1423767503",
-            "key": "A",
-            "variables": []
-        }],
-        "trafficAllocation": [{
-            "entityId": "1423767503",
-            "endOfRange": 10000
-        }],
-        "audienceIds": ["3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"],
-        "forcedVariations": {}
-    }
-    ],
     "version": "4",
     "rollouts": [{
         "experiments": [{
@@ -80,6 +41,49 @@
             "id": "11630490911"
         }],
         "id": "11638870867"
+    },
+    {
+        "experiments": [{
+            "status": "Running",
+            "key": "11488548028",
+            "layerId": "11551226732",
+            "trafficAllocation": [{
+                "entityId": "11557362670",
+                "endOfRange": 10000
+            }],
+            "audienceIds": ["0"],
+            "audienceConditions": "[\"and\", [\"or\", \"3468206642\", \"3988293898\"], [\"or\", \"3988293899\", \"3468206646\", \"3468206647\", \"3468206644\", \"3468206643\"]]",
+            "variations": [{
+                "variables": [],
+                "id": "11557362670",
+                "key": "11557362670",
+                "featureEnabled": true
+            }],
+            "forcedVariations": {},
+            "id": "11488548028"
+        }],
+        "id": "11551226732"
+    },
+    {
+        "experiments": [{
+            "status": "Paused",
+            "key": "11630490912",
+            "layerId": "11638870868",
+            "trafficAllocation": [{
+                "entityId": "11475708559",
+                "endOfRange": 0
+            }],
+            "audienceIds": [],
+            "variations": [{
+                "variables": [],
+                "id": "11475708559",
+                "key": "11475708559",
+                "featureEnabled": false
+            }],
+            "forcedVariations": {},
+            "id": "11630490912"
+        }],
+        "id": "11638870868"
     }
     ],
     "anonymizeIP": false,
@@ -105,6 +109,104 @@
         }],
         "id": "11567102051",
         "key": "feat_with_var"
+    },
+    {
+        "experimentIds": [],
+        "rolloutId": "11551226732",
+        "variables": [],
+        "id": "11567102052",
+        "key": "feat2"
+    },
+    {
+        "experimentIds": ["1323241599"],
+        "rolloutId": "11638870868",
+        "variables": [{
+            "defaultValue": "10",
+            "type": "integer",
+            "id": "11535264367",
+            "key": "z"
+        }],
+        "id": "11567102053",
+        "key": "feat2_with_var"
+    }
+    ],
+    "experiments": [{
+        "status": "Running",
+        "key": "feat_with_var_test",
+        "layerId": "11504144555",
+        "trafficAllocation": [{
+            "entityId": "11617170975",
+            "endOfRange": 10000
+        }],
+        "audienceIds": ["3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"],
+        "variations": [{
+            "variables": [{
+                "id": "11535264366",
+                "value": "xyz"
+            }],
+            "id": "11617170975",
+            "key": "variation_2",
+            "featureEnabled": true
+        }],
+        "forcedVariations": {},
+        "id": "11564051718"
+    },
+    {
+        "id": "1323241597",
+        "key": "typed_audience_experiment",
+        "layerId": "1630555627",
+        "status": "Running",
+        "variations": [{
+            "id": "1423767503",
+            "key": "A",
+            "variables": []
+        }],
+        "trafficAllocation": [{
+            "entityId": "1423767503",
+            "endOfRange": 10000
+        }],
+        "audienceIds": ["3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"],
+        "forcedVariations": {}
+    },
+    {
+        "id": "1323241598",
+        "key": "audience_combinations_experiment",
+        "layerId": "1323241598",
+        "status": "Running",
+        "variations": [{
+            "id": "1423767504",
+            "key": "A",
+            "variables": []
+        }],
+        "trafficAllocation": [{
+            "entityId": "1423767504",
+            "endOfRange": 10000
+        }],
+        "audienceIds": ["0"],
+        "audienceConditions": "[\"and\", [\"or\", \"3468206642\", \"3988293898\"], [\"or\", \"3988293899\", \"3468206646\", \"3468206647\", \"3468206644\", \"3468206643\"]]",
+        "forcedVariations": {}
+    },
+    {
+        "id": "1323241599",
+        "key": "feat2_with_var_test",
+        "layerId": "1323241600",
+        "status": "Running",
+        "variations": [{
+            "variables": [{
+                "id": "11535264367",
+                "value": "150"
+            }],
+            "id": "1423767505",
+            "key": "variation_2",
+            "featureEnabled": true
+        }],
+        "trafficAllocation": [{
+            "entityId": "1423767505",
+            "endOfRange": 10000
+        }],
+        "audienceIds": ["0"],
+        "audienceConditions": "[\"and\", [\"or\", \"3468206642\", \"3988293898\"], [\"or\", \"3988293899\", \"3468206646\", \"3468206647\", \"3468206644\", \"3468206643\"]]",
+        "forcedVariations": {}
     }
     ],
     "audiences": [{
@@ -141,6 +243,16 @@
         "id": "3468206643",
         "name": "$$dummyExactBoolean",
         "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+        "id": "3468206645",
+        "name": "$$dummyMultipleCustomAttrs",
+        "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+        "id": "0",
+        "name": "$$dummy",
+        "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
     }
     ],
     "typedAudiences": [{
@@ -172,6 +284,11 @@
         "id": "3468206643",
         "name": "exactBoolean",
         "conditions": ["and", ["or", ["or", {"name": "should_do_it", "type": "custom_attribute", "match":"exact", "value": true}]]]
+    },
+    {
+        "id": "3468206645",
+        "name": "multiple_custom_attrs",
+        "conditions": ["and", ["or", ["or", {"name": "browser", "type": "custom_attribute", "value": "chrome"}, {"name": "browser", "type": "custom_attribute", "value": "firefox"}]]]
     }
     ],
     "groups": [],
@@ -201,6 +318,14 @@
             "11564051718",
             "1323241597"
         ]
+    },
+    {
+        "key": "user_signed_up",
+        "id": "594090",
+        "experimentIds": [
+            "1323241598",
+            "1323241599"
+        ]
     }],
     "revision": "3"
-} 
+}


### PR DESCRIPTION
Summary
-------
This adds support for audience combinations on experiments. If `experiment.audienceConditions` is present, it will be used as a condition tree where the leaf conditions are audience Ids.

- Experiments can now be evaluated on behalf of either complex audienceConditions or simple audienceIds
- Audience conditions can either be a string defining array of conditions or simply a string of audience id which is then converted to an OR condition.
- Priority will be given to audienceConditions if both audienceIds and audienceConditions are present.

Test plan
---------
- Added unit tests for APIs that pass/fail using various complex audiences with different match types. 
-  Added new unit tests for calling condition tree and custom attribute evaluators. 
-  Added unit tests for Decision Service to check User Targeting.

