### PR TITLE
fix(travis): Excessive logging cause travis build terminated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - gem install slather --no-rdoc --no-ri --no-document --quiet
 script:
   - pod spec lint --quick
-  - if [[ "$TRAVIS_BRANCH" == "master" ]]; then xcodebuild test -quiet -workspace OptimizelySDK.xcworkspace -scheme $SCHEME -configuration Release CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -sdk $TEST_SDK -destination "platform=$PLATFORM,OS=$OS,name=$NAME" ONLY_ACTIVE_ARCH=YES | egrep -B 10 -A 10 "(error|failed|crash|exit|FAILED|Failing|failures)"; fi
+  - if [[ "$TRAVIS_BRANCH" == "master" ]]; then xcodebuild test -quiet -workspace OptimizelySDK.xcworkspace -scheme $SCHEME -configuration Release CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -sdk $TEST_SDK -destination "platform=$PLATFORM,OS=$OS,name=$NAME" ONLY_ACTIVE_ARCH=YES | xcpretty -t; test ${PIPESTATUS[0]} -eq 0; fi
 after_success:
   - slather
   - sleep 5 # https://github.com/travis-ci/travis-ci/issues/4725


### PR DESCRIPTION
## Summary
Moved to xcpretty instead of filtering out error/warning lines with 10 previous/next lines. 
The old procedure was repeating logs if error/warning comes with-in 10 lines. 

## Test plan
Will add commits to see if travis-ci fails on not expected result or not. 
