### PR TITLE
feat(attribute_value): Don't target NAN, INF, -INF and Doubles > 1e53…

### DIFF
--- a/OptimizelySDKCore/OptimizelySDKCore.xcodeproj/project.pbxproj
+++ b/OptimizelySDKCore/OptimizelySDKCore.xcodeproj/project.pbxproj
@@ -229,6 +229,8 @@
 		C77958C4219BFBC400B4CA89 /* OPTLYNSObject+Validation.h in Headers */ = {isa = PBXBuildFile; fileRef = C77958C0219BFBA000B4CA89 /* OPTLYNSObject+Validation.h */; };
 		C77958C5219BFBC700B4CA89 /* OPTLYNSObject+Validation.m in Sources */ = {isa = PBXBuildFile; fileRef = C77958C1219BFBA000B4CA89 /* OPTLYNSObject+Validation.m */; };
 		C77958C6219BFBC800B4CA89 /* OPTLYNSObject+Validation.m in Sources */ = {isa = PBXBuildFile; fileRef = C77958C1219BFBA000B4CA89 /* OPTLYNSObject+Validation.m */; };
+		C7809D1921C11675005725FF /* OPTLYValidationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C7809D1821C11675005725FF /* OPTLYValidationTest.m */; };
+		C7809D1A21C11675005725FF /* OPTLYValidationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C7809D1821C11675005725FF /* OPTLYValidationTest.m */; };
 		EA064BC71DD3FC8800DF7537 /* OPTLYQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = EA064BC51DD3FC8800DF7537 /* OPTLYQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA064BC81DD3FC8800DF7537 /* OPTLYQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = EA064BC51DD3FC8800DF7537 /* OPTLYQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA064BC91DD3FC8800DF7537 /* OPTLYQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = EA064BC61DD3FC8800DF7537 /* OPTLYQueue.m */; };
@@ -635,6 +637,7 @@
 		BE0C3BD9DC6186DB98A667C2 /* Pods_OptimizelySDKCoreTVOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OptimizelySDKCoreTVOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C77958C0219BFBA000B4CA89 /* OPTLYNSObject+Validation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OPTLYNSObject+Validation.h"; sourceTree = "<group>"; };
 		C77958C1219BFBA000B4CA89 /* OPTLYNSObject+Validation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "OPTLYNSObject+Validation.m"; sourceTree = "<group>"; };
+		C7809D1821C11675005725FF /* OPTLYValidationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OPTLYValidationTest.m; sourceTree = "<group>"; };
 		E2E7211C032DF7A75264FDDB /* Pods-OptimizelySDKCoreTVOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OptimizelySDKCoreTVOSTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-OptimizelySDKCoreTVOSTests/Pods-OptimizelySDKCoreTVOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		EA064BC51DD3FC8800DF7537 /* OPTLYQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OPTLYQueue.h; sourceTree = "<group>"; };
 		EA064BC61DD3FC8800DF7537 /* OPTLYQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OPTLYQueue.m; sourceTree = "<group>"; };
@@ -1273,6 +1276,7 @@
 				EA064BCB1DD3FC9F00DF7537 /* OPTLYQueueTest.m */,
 				EA2FAB911DC6FDFA00B1D81B /* OPTLYTestHelper.h */,
 				EA2FAB921DC6FDFA00B1D81B /* OPTLYTestHelper.m */,
+				C7809D1821C11675005725FF /* OPTLYValidationTest.m */,
 				EA2FAB941DC6FDFA00B1D81B /* TestData */,
 			);
 			path = OptimizelySDKCoreTests;
@@ -1991,6 +1995,7 @@
 				59B9E1D120E28DBC002F732E /* OptimizelySwiftTest.swift in Sources */,
 				EA2FABC31DC6FDFA00B1D81B /* OPTLYTestHelper.m in Sources */,
 				EA2FABBD1DC6FDFA00B1D81B /* OPTLYLoggerTest.m in Sources */,
+				C7809D1921C11675005725FF /* OPTLYValidationTest.m in Sources */,
 				EA064BCE1DD3FCD700DF7537 /* OPTLYQueueTest.m in Sources */,
 				5E4C07FB1DFF66B00042B1F8 /* OPTLYNetworkServiceTest.m in Sources */,
 				EA2FABB41DC6FDFA00B1D81B /* OPTLYEventBuilderTest.m in Sources */,
@@ -2092,6 +2097,7 @@
 				3EA818961FFF890E00BEBD41 /* OPTLYNotificationCenterTest.m in Sources */,
 				EA2FABB81DC6FDFA00B1D81B /* OPTLYEventDispatcherTest.m in Sources */,
 				EA2FABA61DC6FDFA00B1D81B /* OPTLYAudienceTest.m in Sources */,
+				C7809D1A21C11675005725FF /* OPTLYValidationTest.m in Sources */,
 				EA2FABB21DC6FDFA00B1D81B /* OPTLYErrorHandlerTest.m in Sources */,
 				0BDF7200202D04EF00EB9742 /* OPTLYNotificationCenterTest2.swift in Sources */,
 				EA2FABC11DC6FDFA00B1D81B /* OPTLYProjectConfigTest.m in Sources */,

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
@@ -208,7 +208,7 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
     
     for (NSString *attributeKey in attributeKeys) {
         NSObject *attributeValue = attributes[attributeKey];
-        if (![OPTLYEventBuilderDefault isValidAttributeValue:attributeValue]) {
+        if (![attributeValue isValidAttributeValue]) {
             NSString *logMessage = [NSString stringWithFormat:OPTLYLoggerMessagesAttributeValueInvalidFormat, attributeKey];
             [config.logger logMessage:logMessage withLevel:OptimizelyLogLevelDebug];
             continue;
@@ -246,39 +246,6 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
     NSNumber *timestamp = [NSNumber numberWithLongLong:currentTimeIntervalCast];
 
     return timestamp;
-}
-
-+ (BOOL)isValidAttributeValue:(NSObject *)value {
-    // check value is NSObject
-    if (!value || [value isEqual:[NSNull null]]) {
-        return false;
-    }
-    // check value is NSString
-    if ([value isKindOfClass:[NSString class]]) {
-        return true;
-    }
-    NSNumber *number = (NSNumber *)value;
-    // check value is NSNumber
-    if (number && [number isKindOfClass:[NSNumber class]]) {
-        const char *objCType = [number objCType];
-        // check NSNumber is of type int, double, bool
-        return (strcmp(objCType, @encode(short)) == 0)
-        || (strcmp(objCType, @encode(unsigned short)) == 0)
-        || (strcmp(objCType, @encode(int)) == 0)
-        || (strcmp(objCType, @encode(unsigned int)) == 0)
-        || (strcmp(objCType, @encode(long)) == 0)
-        || (strcmp(objCType, @encode(unsigned long)) == 0)
-        || (strcmp(objCType, @encode(long long)) == 0)
-        || (strcmp(objCType, @encode(unsigned long long)) == 0)
-        || (strcmp(objCType, @encode(float)) == 0)
-        || (strcmp(objCType, @encode(double)) == 0)
-        || (strcmp(objCType, @encode(char)) == 0)
-        || (strcmp(objCType, @encode(unsigned char)) == 0)
-        || (strcmp(objCType, @encode(bool)) == 0)
-        || [number isEqual:@YES]
-        || [number isEqual:@NO];
-    }
-    return false;
 }
 
 @end

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.h
@@ -55,6 +55,13 @@ NS_ASSUME_NONNULL_BEGIN
  **/
 - (BOOL)isValidAttributeValue;
 
+/**
+ * Returns if object is a valid numeric attribute
+ *
+ * @returns A Bool whether object is a valid numeric attribute.
+ **/
+-(BOOL)isValidNumericAttributeValue;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.h
@@ -48,6 +48,13 @@ NS_ASSUME_NONNULL_BEGIN
  **/
 - (NSString *)getStringOrEmpty;
 
+/**
+ * Returns if object is a valid attribute
+ *
+ * @returns A Bool whether object is a valid attribute.
+ **/
+- (BOOL)isValidAttributeValue;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.h
@@ -56,11 +56,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isValidAttributeValue;
 
 /**
+ * Returns if object is a valid boolean attribute
+ *
+ * @returns A Bool whether object is a valid boolean attribute.
+ **/
+- (BOOL)isValidBooleanAttributeValue;
+
+/**
  * Returns if object is a valid numeric attribute
  *
  * @returns A Bool whether object is a valid numeric attribute.
  **/
--(BOOL)isValidNumericAttributeValue;
+- (BOOL)isValidNumericAttributeValue;
 
 @end
 

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.m
@@ -64,7 +64,10 @@
         if ([self isKindOfClass:[NSString class]]) {
             return true;
         }
-        
+        // check value is Boolean
+        if ([self isValidBooleanAttributeValue]) {
+            return true;
+        }
         //check value is valid numeric attribute
         if ([self isValidNumericAttributeValue]) {
             return true;
@@ -73,7 +76,7 @@
     return false;
 }
 
--(BOOL)isValidNumericAttributeValue {
+-(BOOL)isValidBooleanAttributeValue {
     if (self) {
         NSNumber *number = (NSNumber *)self;
         // check value is NSNumber
@@ -86,8 +89,26 @@
                 || [number isEqual:@NO]) {
                 return true;
             }
+        }
+    }
+    return false;
+}
+
+-(BOOL)isValidNumericAttributeValue {
+    if (self) {
+        NSNumber *number = (NSNumber *)self;
+        // check value is NSNumber
+        if (number && [number isKindOfClass:[NSNumber class]]) {
+            const char *objCType = [number objCType];
+            
             // check for Nan
             if (isnan([number doubleValue])) {
+                return false;
+            }
+            // check NSNumber is bool
+            if ((strcmp(objCType, @encode(bool)) == 0)
+                || [number isEqual:@YES]
+                || [number isEqual:@NO]) {
                 return false;
             }
             // check for infinity

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.m
@@ -54,4 +54,58 @@
     }
     return string;
 }
+
+- (BOOL)isValidAttributeValue {
+    if (self) {
+        if ([self isEqual:[NSNull null]]) {
+            return false;
+        }
+        // check value is NSString
+        if ([self isKindOfClass:[NSString class]]) {
+            return true;
+        }
+        NSNumber *number = (NSNumber *)self;
+        // check value is NSNumber
+        if (number && [number isKindOfClass:[NSNumber class]]) {
+            const char *objCType = [number objCType];
+            
+            // check NSNumber is bool
+            if ((strcmp(objCType, @encode(bool)) == 0)
+                || [number isEqual:@YES]
+                || [number isEqual:@NO]) {
+                return true;
+            }
+            // check for Nan
+            if ([number isEqualToNumber:[NSDecimalNumber notANumber]]) {
+                return false;
+            }
+            // check for infinity
+            if (isinf([number doubleValue])) {
+                return false;
+            }
+            // check NSNumber is of type int, double
+            Boolean isNumeric = (strcmp(objCType, @encode(short)) == 0)
+            || (strcmp(objCType, @encode(unsigned short)) == 0)
+            || (strcmp(objCType, @encode(int)) == 0)
+            || (strcmp(objCType, @encode(unsigned int)) == 0)
+            || (strcmp(objCType, @encode(long)) == 0)
+            || (strcmp(objCType, @encode(unsigned long)) == 0)
+            || (strcmp(objCType, @encode(long long)) == 0)
+            || (strcmp(objCType, @encode(unsigned long long)) == 0)
+            || (strcmp(objCType, @encode(float)) == 0)
+            || (strcmp(objCType, @encode(double)) == 0)
+            || (strcmp(objCType, @encode(char)) == 0)
+            || (strcmp(objCType, @encode(unsigned char)) == 0);
+            
+            if (isNumeric) {
+                //double is the only data type capable of handling values greater than 3.40282e+038 && less than 1.17549e-038
+                //https://stackoverflow.com/a/12322917/4849178
+                // check for value greater than 1e53 and less than -1e53
+                NSNumber *maxValue = [NSNumber numberWithDouble:exp(53)];
+                return (fabs([number doubleValue]) < [maxValue doubleValue]);
+            }
+        }
+    }
+    return false;
+}
 @end

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.m
@@ -64,6 +64,17 @@
         if ([self isKindOfClass:[NSString class]]) {
             return true;
         }
+        
+        //check value is valid numeric attribute
+        if ([self isValidNumericAttributeValue]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+-(BOOL)isValidNumericAttributeValue {
+    if (self) {
         NSNumber *number = (NSNumber *)self;
         // check value is NSNumber
         if (number && [number isKindOfClass:[NSNumber class]]) {
@@ -98,14 +109,12 @@
             || (strcmp(objCType, @encode(unsigned char)) == 0);
             
             if (isNumeric) {
-                //double is the only data type capable of handling values greater than 3.40282e+038 && less than 1.17549e-038
-                //https://stackoverflow.com/a/12322917/4849178
-                // check for value greater than 1e53 and less than -1e53
-                NSNumber *maxValue = [NSNumber numberWithDouble:exp(53)];
+                NSNumber *maxValue = [NSNumber numberWithDouble:pow(2,53)];
                 return (fabs([number doubleValue]) < [maxValue doubleValue]);
             }
         }
     }
     return false;
 }
+
 @end

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.m
@@ -76,7 +76,7 @@
                 return true;
             }
             // check for Nan
-            if ([number isEqualToNumber:[NSDecimalNumber notANumber]]) {
+            if (isnan([number doubleValue])) {
                 return false;
             }
             // check for infinity

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.m
@@ -110,7 +110,7 @@
             
             if (isNumeric) {
                 NSNumber *maxValue = [NSNumber numberWithDouble:pow(2,53)];
-                return (fabs([number doubleValue]) < [maxValue doubleValue]);
+                return (fabs([number doubleValue]) <= [maxValue doubleValue]);
             }
         }
     }

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYValidationTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYValidationTest.m
@@ -45,6 +45,8 @@
     XCTAssertTrue([(NSObject *)@0.0 isValidAttributeValue]);
     XCTAssertTrue([(NSObject *)@"" isValidAttributeValue]);
     XCTAssertTrue([(NSObject *)@"test_value" isValidAttributeValue]);
+    XCTAssertTrue([(NSObject *)[NSNumber numberWithDouble:(pow(2, 53))] isValidAttributeValue]);
+    XCTAssertTrue([(NSObject *)[NSNumber numberWithDouble:(-pow(2, 53))] isValidAttributeValue]);
     XCTAssertTrue([(NSObject *)[NSNumber numberWithLongLong:(pow(2, 53))] isValidAttributeValue]);
     XCTAssertTrue([(NSObject *)[NSNumber numberWithLongLong:(-pow(2, 53))] isValidAttributeValue]);
     XCTAssertTrue([(NSObject *)[NSNumber numberWithUnsignedLongLong:(pow(2, 53))] isValidAttributeValue]);
@@ -58,6 +60,8 @@
     XCTAssertFalse([(NSObject *)[NSNumber numberWithFloat:INFINITY] isValidAttributeValue]);
     XCTAssertFalse([(NSObject *)[NSNumber numberWithFloat:-INFINITY] isValidAttributeValue]);
     XCTAssertFalse([(NSObject *)[NSNumber numberWithDouble:NAN] isValidAttributeValue]);
+    XCTAssertFalse([(NSObject *)[NSNumber numberWithDouble:(pow(2, 53) + 2)] isValidAttributeValue]);
+    XCTAssertFalse([(NSObject *)[NSNumber numberWithDouble:(-pow(2, 53) - 2)] isValidAttributeValue]);
     XCTAssertFalse([(NSObject *)[NSNumber numberWithLongLong:(pow(2, 53) + 2)] isValidAttributeValue]);
     XCTAssertFalse([(NSObject *)[NSNumber numberWithLongLong:(-pow(2, 53) - 2)] isValidAttributeValue]);
     XCTAssertFalse([(NSObject *)[NSNumber numberWithUnsignedLongLong:(pow(2, 53) + 2)] isValidAttributeValue]);

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYValidationTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYValidationTest.m
@@ -45,6 +45,8 @@
     XCTAssertTrue([(NSObject *)@0.0 isValidAttributeValue]);
     XCTAssertTrue([(NSObject *)@"" isValidAttributeValue]);
     XCTAssertTrue([(NSObject *)@"test_value" isValidAttributeValue]);
+    XCTAssertTrue([(NSObject *)[NSNumber numberWithDouble:(pow(2, 53) - 1)] isValidAttributeValue]);
+    XCTAssertTrue([(NSObject *)[NSNumber numberWithDouble:(-pow(2, 53) + 1)] isValidAttributeValue]);
 }
 
 - (void)testMethodIsValidAttributeValueReturnsFalseForInvalidData
@@ -53,8 +55,10 @@
     XCTAssertFalse([(NSObject *)@{} isValidAttributeValue]);
     XCTAssertFalse([(NSObject *)@[] isValidAttributeValue]);
     XCTAssertFalse([(NSObject *)[NSNumber numberWithFloat:INFINITY] isValidAttributeValue]);
+    XCTAssertFalse([(NSObject *)[NSNumber numberWithFloat:-INFINITY] isValidAttributeValue]);
     XCTAssertFalse([(NSObject *)[NSNumber numberWithDouble:NAN] isValidAttributeValue]);
-    XCTAssertFalse([(NSObject *)[NSNumber numberWithDouble:(exp(53) + 1)] isValidAttributeValue]);
+    XCTAssertFalse([(NSObject *)[NSNumber numberWithDouble:(pow(2, 53))] isValidAttributeValue]);
+    XCTAssertFalse([(NSObject *)[NSNumber numberWithDouble:(-pow(2, 53))] isValidAttributeValue]);
 }
 
 @end

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYValidationTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYValidationTest.m
@@ -45,8 +45,9 @@
     XCTAssertTrue([(NSObject *)@0.0 isValidAttributeValue]);
     XCTAssertTrue([(NSObject *)@"" isValidAttributeValue]);
     XCTAssertTrue([(NSObject *)@"test_value" isValidAttributeValue]);
-    XCTAssertTrue([(NSObject *)[NSNumber numberWithDouble:(pow(2, 53))] isValidAttributeValue]);
-    XCTAssertTrue([(NSObject *)[NSNumber numberWithDouble:(-pow(2, 53))] isValidAttributeValue]);
+    XCTAssertTrue([(NSObject *)[NSNumber numberWithLongLong:(pow(2, 53))] isValidAttributeValue]);
+    XCTAssertTrue([(NSObject *)[NSNumber numberWithLongLong:(-pow(2, 53))] isValidAttributeValue]);
+    XCTAssertTrue([(NSObject *)[NSNumber numberWithUnsignedLongLong:(pow(2, 53))] isValidAttributeValue]);
 }
 
 - (void)testMethodIsValidAttributeValueReturnsFalseForInvalidData
@@ -57,8 +58,9 @@
     XCTAssertFalse([(NSObject *)[NSNumber numberWithFloat:INFINITY] isValidAttributeValue]);
     XCTAssertFalse([(NSObject *)[NSNumber numberWithFloat:-INFINITY] isValidAttributeValue]);
     XCTAssertFalse([(NSObject *)[NSNumber numberWithDouble:NAN] isValidAttributeValue]);
-    XCTAssertFalse([(NSObject *)[NSNumber numberWithDouble:(pow(2, 53) + 2)] isValidAttributeValue]);
-    XCTAssertFalse([(NSObject *)[NSNumber numberWithDouble:(-pow(2, 53) - 2)] isValidAttributeValue]);
+    XCTAssertFalse([(NSObject *)[NSNumber numberWithLongLong:(pow(2, 53) + 2)] isValidAttributeValue]);
+    XCTAssertFalse([(NSObject *)[NSNumber numberWithLongLong:(-pow(2, 53) - 2)] isValidAttributeValue]);
+    XCTAssertFalse([(NSObject *)[NSNumber numberWithUnsignedLongLong:(pow(2, 53) + 2)] isValidAttributeValue]);
 }
 
 @end

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYValidationTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYValidationTest.m
@@ -1,0 +1,60 @@
+/****************************************************************************
+ * Copyright 2018, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+#import <XCTest/XCTest.h>
+#import "OPTLYNSObject+Validation.h"
+
+@interface OPTLYValidationTest : XCTestCase
+
+@end
+
+@implementation OPTLYValidationTest
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+#pragma mark - Test Method isValidAttributeValue
+
+- (void)testMethodIsValidAttributeValueReturnsTrueForValidData
+{
+    XCTAssertTrue([(NSObject *)@false isValidAttributeValue]);
+    XCTAssertTrue([(NSObject *)@true isValidAttributeValue]);
+    XCTAssertTrue([(NSObject *)@YES isValidAttributeValue]);
+    XCTAssertTrue([(NSObject *)@NO isValidAttributeValue]);
+    XCTAssertTrue([(NSObject *)@0 isValidAttributeValue]);
+    XCTAssertTrue([(NSObject *)@0.0 isValidAttributeValue]);
+    XCTAssertTrue([(NSObject *)@"" isValidAttributeValue]);
+    XCTAssertTrue([(NSObject *)@"test_value" isValidAttributeValue]);
+}
+
+- (void)testMethodIsValidAttributeValueReturnsFalseForInvalidData
+{
+    XCTAssertFalse([(NSObject *)nil isValidAttributeValue]);
+    XCTAssertFalse([(NSObject *)@{} isValidAttributeValue]);
+    XCTAssertFalse([(NSObject *)@[] isValidAttributeValue]);
+    XCTAssertFalse([(NSObject *)[NSNumber numberWithFloat:INFINITY] isValidAttributeValue]);
+    XCTAssertFalse([(NSObject *)[NSNumber numberWithDouble:NAN] isValidAttributeValue]);
+    XCTAssertFalse([(NSObject *)[NSNumber numberWithDouble:(exp(53) + 1)] isValidAttributeValue]);
+}
+
+@end

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYValidationTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYValidationTest.m
@@ -45,8 +45,8 @@
     XCTAssertTrue([(NSObject *)@0.0 isValidAttributeValue]);
     XCTAssertTrue([(NSObject *)@"" isValidAttributeValue]);
     XCTAssertTrue([(NSObject *)@"test_value" isValidAttributeValue]);
-    XCTAssertTrue([(NSObject *)[NSNumber numberWithDouble:(pow(2, 53) - 1)] isValidAttributeValue]);
-    XCTAssertTrue([(NSObject *)[NSNumber numberWithDouble:(-pow(2, 53) + 1)] isValidAttributeValue]);
+    XCTAssertTrue([(NSObject *)[NSNumber numberWithDouble:(pow(2, 53))] isValidAttributeValue]);
+    XCTAssertTrue([(NSObject *)[NSNumber numberWithDouble:(-pow(2, 53))] isValidAttributeValue]);
 }
 
 - (void)testMethodIsValidAttributeValueReturnsFalseForInvalidData
@@ -57,8 +57,8 @@
     XCTAssertFalse([(NSObject *)[NSNumber numberWithFloat:INFINITY] isValidAttributeValue]);
     XCTAssertFalse([(NSObject *)[NSNumber numberWithFloat:-INFINITY] isValidAttributeValue]);
     XCTAssertFalse([(NSObject *)[NSNumber numberWithDouble:NAN] isValidAttributeValue]);
-    XCTAssertFalse([(NSObject *)[NSNumber numberWithDouble:(pow(2, 53))] isValidAttributeValue]);
-    XCTAssertFalse([(NSObject *)[NSNumber numberWithDouble:(-pow(2, 53))] isValidAttributeValue]);
+    XCTAssertFalse([(NSObject *)[NSNumber numberWithDouble:(pow(2, 53) + 2)] isValidAttributeValue]);
+    XCTAssertFalse([(NSObject *)[NSNumber numberWithDouble:(-pow(2, 53) - 2)] isValidAttributeValue]);
 }
 
 @end


### PR DESCRIPTION
Summary
-------
Don't target NAN, INF, -INF or > 1e53 doubles. 
Modified isValidAttributeValue and added it to NSObject Category.
Created new Test file for Validation testing.

Test plan
---------

Issues
------
OASIS-3658
https://github.com/optimizely/python-sdk/pull/146#discussion_r237850806
