### PR TITLE
fix(audienceeval): Multiple fixes

### DIFF
--- a/OptimizelySDKCore/OptimizelySDKCore.xcodeproj/project.pbxproj
+++ b/OptimizelySDKCore/OptimizelySDKCore.xcodeproj/project.pbxproj
@@ -233,6 +233,8 @@
 		C77958C6219BFBC800B4CA89 /* OPTLYNSObject+Validation.m in Sources */ = {isa = PBXBuildFile; fileRef = C77958C1219BFBA000B4CA89 /* OPTLYNSObject+Validation.m */; };
 		C779881321CBC22A002AAEC8 /* OPTLYValidationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C779881221CBC22A002AAEC8 /* OPTLYValidationTest.m */; };
 		C779881421CBC22A002AAEC8 /* OPTLYValidationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = C779881221CBC22A002AAEC8 /* OPTLYValidationTest.m */; };
+		C781DEA921E8A44400EF35EC /* audience_targeting.json in Resources */ = {isa = PBXBuildFile; fileRef = C781DEA821E8A44400EF35EC /* audience_targeting.json */; };
+		C781DEAA21E8A44400EF35EC /* audience_targeting.json in Resources */ = {isa = PBXBuildFile; fileRef = C781DEA821E8A44400EF35EC /* audience_targeting.json */; };
 		C78F98B7219ADEA600808062 /* OPTLYAudienceBaseCondition.h in Headers */ = {isa = PBXBuildFile; fileRef = C78F98B4219ADE9600808062 /* OPTLYAudienceBaseCondition.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C78F98B8219ADEA700808062 /* OPTLYAudienceBaseCondition.h in Headers */ = {isa = PBXBuildFile; fileRef = C78F98B4219ADE9600808062 /* OPTLYAudienceBaseCondition.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C78F98B9219ADEAB00808062 /* OPTLYAudienceBaseCondition.m in Sources */ = {isa = PBXBuildFile; fileRef = C78F98B5219ADE9600808062 /* OPTLYAudienceBaseCondition.m */; };
@@ -647,6 +649,7 @@
 		C77958C0219BFBA000B4CA89 /* OPTLYNSObject+Validation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "OPTLYNSObject+Validation.h"; sourceTree = "<group>"; };
 		C77958C1219BFBA000B4CA89 /* OPTLYNSObject+Validation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "OPTLYNSObject+Validation.m"; sourceTree = "<group>"; };
 		C779881221CBC22A002AAEC8 /* OPTLYValidationTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OPTLYValidationTest.m; sourceTree = "<group>"; };
+		C781DEA821E8A44400EF35EC /* audience_targeting.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = audience_targeting.json; sourceTree = "<group>"; };
 		C78F98B4219ADE9600808062 /* OPTLYAudienceBaseCondition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OPTLYAudienceBaseCondition.h; sourceTree = "<group>"; };
 		C78F98B5219ADE9600808062 /* OPTLYAudienceBaseCondition.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OPTLYAudienceBaseCondition.m; sourceTree = "<group>"; };
 		C7ACD4FD218C2E4A008EC52E /* typed_audience_datafile.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = typed_audience_datafile.json; sourceTree = "<group>"; };
@@ -1197,6 +1200,7 @@
 		EA2FAB941DC6FDFA00B1D81B /* TestData */ = {
 			isa = PBXGroup;
 			children = (
+				C781DEA821E8A44400EF35EC /* audience_targeting.json */,
 				C7ACD4FD218C2E4A008EC52E /* typed_audience_datafile.json */,
 				EA2FAB951DC6FDFA00B1D81B /* BucketerTestsDatafile.json */,
 				3E92800D1F26AD4700214C58 /* BucketerTestsDatafile2.json */,
@@ -1705,6 +1709,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C781DEA921E8A44400EF35EC /* audience_targeting.json in Resources */,
 				EA2FABCC1DC6FDFA00B1D81B /* optimizely_6372300739.json in Resources */,
 				EA2FABD81DC6FDFA00B1D81B /* optimizely_7519590183.json in Resources */,
 				EA2FABD51DC6FDFA00B1D81B /* test_data_50_experiments.json in Resources */,
@@ -1731,6 +1736,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C781DEAA21E8A44400EF35EC /* audience_targeting.json in Resources */,
 				3E92800E1F26AD4700214C58 /* BucketerTestsDatafile2.json in Resources */,
 				EA2FABCD1DC6FDFA00B1D81B /* optimizely_6372300739.json in Resources */,
 				EA2FABD91DC6FDFA00B1D81B /* optimizely_7519590183.json in Resources */,

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYAudience.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYAudience.m
@@ -42,15 +42,12 @@
 }
 
 - (nullable NSNumber *)evaluateConditionsWithAttributes:(NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
-    for (NSObject<OPTLYCondition> *condition in self.conditions) {
-        NSNumber *result = [condition evaluateConditionsWithAttributes:attributes projectConfig:config];
-        if (result != NULL && [result boolValue] == true) {
-            // if user satisfies any conditions, return true.
-            return [NSNumber numberWithBool:true];
-        }
+    
+    NSObject<OPTLYCondition> *condition = (NSObject<OPTLYCondition> *)[self.conditions firstObject];
+    if (condition) {
+        return [condition evaluateConditionsWithAttributes:attributes projectConfig:config];
     }
-    // if user doesn't satisfy any conditions, return false.
-    return [NSNumber numberWithBool:false];
+    return nil;
 }
 
 @end

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYAudienceBaseCondition.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYAudienceBaseCondition.m
@@ -30,12 +30,7 @@
     }
     
     OPTLYAudience *audience = [config getAudienceForId:self.audienceId];
-    BOOL areAttributesValid = [[audience evaluateConditionsWithAttributes:attributes projectConfig:config] boolValue];
-    if (areAttributesValid) {
-        return [NSNumber numberWithBool:true];;
-    }
-    
-    return [NSNumber numberWithBool:false];
+    return [audience evaluateConditionsWithAttributes:attributes projectConfig:config];
 }
 
 @end

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYBaseCondition.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYBaseCondition.h
@@ -34,7 +34,7 @@
 /// Condition name
 @property (nonatomic, strong) NSString *name;
 /// Condition type
-@property (nonatomic, strong) NSString *type;
+@property (nonatomic, strong, nullable) NSString<OPTLYOptional> *type;
 /// Condition value
 @property (nonatomic, strong, nullable) NSObject<OPTLYOptional> *value;
 /// Condition match type

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYBaseCondition.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYBaseCondition.m
@@ -33,18 +33,7 @@
 }
 
 + (BOOL) isBaseConditionJSON:(NSData *)jsonData {
-    if (![jsonData isKindOfClass:[NSDictionary class]]) {
-        return false;
-    }
-    else {
-        NSDictionary *dict = (NSDictionary *)jsonData;
-        
-        if (dict[OPTLYDatafileKeysConditionName] != nil &&
-            dict[OPTLYDatafileKeysConditionType] != nil) {
-            return true;
-        }
-        return false;
-    }
+    return [jsonData isKindOfClass:[NSDictionary class]];
 }
 
 -(nullable NSNumber *)evaluateMatchTypeExact:(NSDictionary<NSString *, NSObject *> *)attributes{
@@ -116,15 +105,15 @@
         //Check if given type is the required type
         return NULL;
     }
-    else if (!self.match || [self.match isEqualToString:@""]){
-        //Check if given match is empty, if so, opt for legacy Exact Matching
-        self.match = OPTLYDatafileKeysMatchTypeExact;
-    }
     else if (self.value == NULL && ![self.match isEqualToString:OPTLYDatafileKeysMatchTypeExists]){
         //Check if given value is null, which is only acceptable if match type is Exists
         return NULL;
     }
-    
+    if (!self.match || [self.match isEqualToString:@""]){
+        //Check if given match is empty, if so, opt for legacy Exact Matching
+        self.match = OPTLYDatafileKeysMatchTypeExact;
+    }
+
     SWITCH(self.match){
         CASE(OPTLYDatafileKeysMatchTypeExact) {
             return [self evaluateMatchTypeExact: attributes];

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYCondition.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYCondition.m
@@ -124,6 +124,10 @@
         return nil;
     }
     
+    if ([jsonArray count] == 0) {
+        return (NSArray<OPTLYCondition> *)@[];
+    }
+    
     if ([OPTLYAudienceBaseCondition isBaseConditionJSON:jsonArray[1]]) { //base case condition
         
         // generate all base conditions

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYExperiment.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYExperiment.m
@@ -57,15 +57,11 @@ NSString * const OPTLYExperimentStatusRunning = @"Running";
 
 - (nullable NSNumber *)evaluateConditionsWithAttributes:(NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
 
-    for (NSObject<OPTLYCondition> *condition in self.audienceConditions) {
-        NSNumber *result = [condition evaluateConditionsWithAttributes:attributes projectConfig:config];
-        if (result != NULL && [result boolValue] == true) {
-            // if user satisfies any conditions, return true.
-            return [NSNumber numberWithBool:true];
-        }
+    NSObject<OPTLYCondition> *condition = (NSObject<OPTLYCondition> *)[self.audienceConditions firstObject];
+    if (condition) {
+        return [condition evaluateConditionsWithAttributes:attributes projectConfig:config];
     }
-    // if user doesn't satisfy any conditions, return false.
-    return [NSNumber numberWithBool:false];
+    return nil;
 }
 
 - (void)setGroupId:(NSString *)groupId {

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYConditionTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYConditionTest.m
@@ -168,7 +168,7 @@
     NSDictionary<NSString *, NSObject *> *userAttributes = @{
                                                              @"house": @"Gryffindor"
                                                              };
-    NSArray *notConditionArray = @[@"not", @"2"];
+    NSArray *notConditionArray = @[@"not", @"3988293898"];
     NSArray *conditions = [OPTLYCondition deserializeAudienceConditionsJSONArray:notConditionArray];
     XCTAssertNotNil(conditions);
     
@@ -564,6 +564,21 @@
     XCTAssertEqualObjects(condition1.audienceId, @"1");
     OPTLYAudienceBaseCondition *condition2 = (OPTLYAudienceBaseCondition *)orCondition.subConditions[1];
     XCTAssertEqualObjects(condition2.audienceId, @"2");
+}
+
+- (void)testDeserializeWithComplexLeafConditions {
+    NSString *conditionString = @"[\"and\", [\"or\",\"1\",\"2\"], \"1\"]";
+    NSArray *conditionStringJSONArray = [conditionString getValidAudienceConditionsArray];
+    NSArray *conditionsArray = [OPTLYCondition deserializeAudienceConditionsJSONArray:conditionStringJSONArray];
+    XCTAssertNotNil(conditionsArray);
+    XCTAssertTrue([conditionsArray[0] isKindOfClass:[OPTLYAndCondition class]]);
+    OPTLYAndCondition *andCondition = conditionsArray[0];
+    XCTAssertTrue(andCondition.subConditions.count == 2);
+    XCTAssertTrue([andCondition.subConditions[0] isKindOfClass:[OPTLYOrCondition class]]);
+    XCTAssertTrue([andCondition.subConditions[1] isKindOfClass:[OPTLYAudienceBaseCondition class]]);
+    OPTLYOrCondition *orCondition = (OPTLYOrCondition *)andCondition.subConditions[0];
+    XCTAssertTrue([orCondition.subConditions[0] isKindOfClass:[OPTLYAudienceBaseCondition class]]);
+    XCTAssertTrue([orCondition.subConditions[1] isKindOfClass:[OPTLYAudienceBaseCondition class]]);
 }
 
 - (void)testDeserializeComplexConditions {

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYConditionTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYConditionTest.m
@@ -110,6 +110,15 @@
 
 // MARK:- NOT Condition Tests
 
+- (void)testNotEvaluatorReturnsNullWhenEmptyOrNullAttributes {
+    NSDictionary *attributesPassOrValue = @{@"device_type" : [NSNull null]};
+    OPTLYNotCondition *notCondition = (OPTLYNotCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithNot]];
+    XCTAssertNil([notCondition evaluateConditionsWithAttributes:attributesPassOrValue projectConfig:nil]);
+    
+    attributesPassOrValue = @{};
+    XCTAssertNil([notCondition evaluateConditionsWithAttributes:attributesPassOrValue projectConfig:nil]);
+}
+
 - (void)testNotEvaluatorReturnsNullWhenOperandEvaluateToNull {
     NSDictionary *attributesPassOrValue = @{@"device_type" : @123};
     OPTLYNotCondition *notCondition = (OPTLYNotCondition *)[self getFirstConditionFromArray:[self kAudienceConditionsWithNot]];
@@ -174,6 +183,19 @@
     
     OPTLYNotCondition *notCondition = (OPTLYNotCondition *)[conditions firstObject];
     XCTAssertTrue([[notCondition evaluateConditionsWithAttributes:userAttributes projectConfig:self.optimizelyTypedAudience.config] boolValue]);
+}
+
+- (void)testNotConditionReturnsNilWithComplexAudienceConditionWhenEmptyOrNullAttributes {
+    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+                                                             @"house": [NSNull null]
+                                                             };
+    NSArray *notConditionArray = @[@"not", @"3988293898"];
+    NSArray *conditions = [OPTLYCondition deserializeAudienceConditionsJSONArray:notConditionArray];
+    OPTLYNotCondition *notCondition = (OPTLYNotCondition *)[conditions firstObject];
+    XCTAssertNil([notCondition evaluateConditionsWithAttributes:userAttributes projectConfig:self.optimizelyTypedAudience.config]);
+    
+    userAttributes = @{};
+    XCTAssertNil([notCondition evaluateConditionsWithAttributes:userAttributes projectConfig:self.optimizelyTypedAudience.config]);
 }
 
 // MARK:- OR Condition Tests

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYConditionTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYConditionTest.m
@@ -505,6 +505,35 @@
     XCTAssertNil(conditionsArray);
 }
 
+- (void)testConditionComplexAudienceConditionCaseDeserializationWithNoContainerAndSingleAudienceId {
+    NSArray *andConditionArray = @[@"1"];
+    NSArray *conditions = [OPTLYCondition deserializeAudienceConditionsJSONArray:andConditionArray];
+    XCTAssertNotNil(conditions);
+    XCTAssertTrue(conditions.count == 1);
+    XCTAssertTrue([conditions[0] isKindOfClass:[OPTLYOrCondition class]]);
+    OPTLYOrCondition *orCondition = conditions[0];
+    XCTAssertTrue(orCondition.subConditions.count == 1);
+    XCTAssertTrue([orCondition.subConditions[0] isKindOfClass:[OPTLYAudienceBaseCondition class]]);
+    OPTLYAudienceBaseCondition *condition1 = (OPTLYAudienceBaseCondition *)orCondition.subConditions[0];
+    XCTAssertEqualObjects(condition1.audienceId, @"1");
+}
+
+- (void)testConditionComplexAudienceConditionCaseDeserializationWithNoContainerAndMultipleAudienceIds {
+    NSArray *andConditionArray = @[@"1",@"2"];
+    NSArray *conditions = [OPTLYCondition deserializeAudienceConditionsJSONArray:andConditionArray];
+    XCTAssertNotNil(conditions);
+    XCTAssertTrue(conditions.count == 1);
+    XCTAssertTrue([conditions[0] isKindOfClass:[OPTLYOrCondition class]]);
+    OPTLYOrCondition *orCondition = conditions[0];
+    XCTAssertTrue(orCondition.subConditions.count == 2);
+    XCTAssertTrue([orCondition.subConditions[0] isKindOfClass:[OPTLYAudienceBaseCondition class]]);
+    XCTAssertTrue([orCondition.subConditions[1] isKindOfClass:[OPTLYAudienceBaseCondition class]]);
+    OPTLYAudienceBaseCondition *condition1 = (OPTLYAudienceBaseCondition *)orCondition.subConditions[0];
+    XCTAssertEqualObjects(condition1.audienceId, @"1");
+    OPTLYAudienceBaseCondition *condition2 = (OPTLYAudienceBaseCondition *)orCondition.subConditions[1];
+    XCTAssertEqualObjects(condition2.audienceId, @"2");
+}
+
 - (void)testConditionComplexAudienceConditionCaseDeserializationWithAndContainer {
     NSArray *andConditionArray = @[@"and", @"1",@"2"];
     NSArray *conditions = [OPTLYCondition deserializeAudienceConditionsJSONArray:andConditionArray];

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYConditionTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYConditionTest.m
@@ -25,6 +25,7 @@
 #import "OPTLYErrorHandler.h"
 #import "OPTLYLogger.h"
 #import "OPTLYNSObject+Validation.h"
+#import "OPTLYVariation.h"
 
 @interface OPTLYConditionTest : XCTestCase
 
@@ -196,6 +197,23 @@
     
     userAttributes = @{};
     XCTAssertNil([notCondition evaluateConditionsWithAttributes:userAttributes projectConfig:self.optimizelyTypedAudience.config]);
+    
+    Optimizely *_optimizely = [[Optimizely alloc] initWithBuilder:[OPTLYBuilder builderWithBlock:^(OPTLYBuilder * _Nullable builder) {
+        builder.datafile = [OPTLYTestHelper loadJSONDatafileIntoDataObject:@"audience_targeting"];
+    }]];
+
+    OPTLYVariation *variation = [_optimizely activate:@"ab_running_exp_audience_combo_not_foo" userId:@"user1"];
+    XCTAssertNil(variation);
+    
+    variation = [_optimizely activate:@"ab_running_exp_audience_combo_not_foo" userId:@"user1" attributes:nil];
+    XCTAssertNil(variation);
+    
+    variation = [_optimizely activate:@"ab_running_exp_audience_combo_not_foo" userId:@"user1" attributes:@{}];
+    XCTAssertNil(variation);
+    
+    userAttributes = @{@"s_foo": @"__foo"};
+    variation = [_optimizely activate:@"ab_running_exp_audience_combo_not_foo" userId:@"user1" attributes:userAttributes];
+    XCTAssertEqualObjects(variation.variationKey, @"all_traffic_variation");
 }
 
 // MARK:- OR Condition Tests

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYConditionTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYConditionTest.m
@@ -488,7 +488,7 @@
     NSArray *conditionStringJSONArray = [conditionString getValidConditionsArray];
     NSError *error = nil;
     NSArray *conditionsArray = [OPTLYCondition deserializeJSONArray:conditionStringJSONArray error:&error];
-    XCTAssertNil(conditionsArray);
+    XCTAssertTrue(conditionsArray);
 }
 
 - (void)testDeserializeConditionsEmptyConditions {

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYTypedAudienceTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYTypedAudienceTest.m
@@ -189,6 +189,36 @@ static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"n
     XCTAssertTrue([[audience evaluateConditionsWithAttributes:NULL projectConfig:nil] boolValue]);
 }
 
+///MARK:- Invalid Base Condition Tests
+
+- (void)testEvaluateReturnsNullWithInvalidBaseCondition {
+    NSDictionary *attributesPassOrValue1 = @{@"name": @"device_type"};
+    NSDictionary *attributesPassOrValue2 = @{@"device_type" : @"iPhone"};
+    NSError *err;
+    OPTLYBaseCondition *condition = [[OPTLYBaseCondition alloc] initWithDictionary:attributesPassOrValue1 error:&err];
+    XCTAssertNil([condition evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil]);
+    
+    NSDictionary *attributesPassOrValue3 = @{@"name": @"device_type",
+                                             @"value": @"iPhone"};
+    condition = [[OPTLYBaseCondition alloc] initWithDictionary:attributesPassOrValue3 error:&err];
+    XCTAssertNil([condition evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil]);
+    
+    NSDictionary *attributesPassOrValue4 = @{@"name": @"device_type",
+                                             @"match": @"exact"};
+    condition = [[OPTLYBaseCondition alloc] initWithDictionary:attributesPassOrValue4 error:&err];
+    XCTAssertNil([condition evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil]);
+    
+    NSDictionary *attributesPassOrValue5 = @{@"name": @"device_type",
+                                             @"type": @"invalid"};
+    condition = [[OPTLYBaseCondition alloc] initWithDictionary:attributesPassOrValue5 error:&err];
+    XCTAssertNil([condition evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil]);
+    
+    NSDictionary *attributesPassOrValue6 = @{@"name": @"device_type",
+                                             @"type": @"custom_attribute"};
+    condition = [[OPTLYBaseCondition alloc] initWithDictionary:attributesPassOrValue6 error:&err];
+    XCTAssertNil([condition evaluateConditionsWithAttributes:attributesPassOrValue2 projectConfig:nil]);
+}
+
 ///MARK:- Invalid input Tests
 
 - (void)testEvaluateReturnsNullWithInvalidConditionType {

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
@@ -1414,6 +1414,69 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 
 //Test that activate calls dispatch_event with right params and returns expected
 //variation when attributes are provided and complex audience conditions are met.
+
+- (void)testActivateWithAttributesComplexAudienceAndMatchingAttributes {
+    
+     Optimizely *_optimizely = [[Optimizely alloc] initWithBuilder:[OPTLYBuilder builderWithBlock:^(OPTLYBuilder * _Nullable builder) {
+        builder.datafile = [OPTLYTestHelper loadJSONDatafileIntoDataObject:@"audience_targeting"];
+        builder.logger = [[OPTLYLoggerDefault alloc] initWithLogLevel:OptimizelyLogLevelOff];;
+        builder.errorHandler = [OPTLYErrorHandlerNoOp new];
+    }]];
+    
+    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+                                                             @"s_foo": @"foo",
+                                                             @"b_true": @"N/A",
+                                                             @"i_42": @43,
+                                                             @"d_4_2": @4.2
+                                                             };
+    
+    OPTLYVariation *variation = [_optimizely activate:@"ab_running_exp_audience_combo_exact_foo_and__42_or_4_2" userId:@"test_user_1" attributes:userAttributes callback:^(NSError *error) {
+    }];
+    XCTAssertEqualObjects(@"all_traffic_variation", variation.variationKey);
+    
+    userAttributes = @{
+                       @"s_foo": @"foo",
+                       @"b_true": @"N/A",
+                       @"i_42": @42,
+                       @"d_4_2": @4.3
+                       };
+    
+    variation = [_optimizely activate:@"ab_running_exp_audience_combo_exact_foo_and__42_or_4_2" userId:@"test_user_1" attributes:userAttributes callback:^(NSError *error) {
+    }];
+    XCTAssertEqualObjects(@"all_traffic_variation", variation.variationKey);
+}
+
+- (void)testActivateWithAttributesComplexAudienceAndNoMatchingAttributes {
+    
+    Optimizely *_optimizely = [[Optimizely alloc] initWithBuilder:[OPTLYBuilder builderWithBlock:^(OPTLYBuilder * _Nullable builder) {
+        builder.datafile = [OPTLYTestHelper loadJSONDatafileIntoDataObject:@"audience_targeting"];
+        builder.logger = [[OPTLYLoggerDefault alloc] initWithLogLevel:OptimizelyLogLevelOff];;
+        builder.errorHandler = [OPTLYErrorHandlerNoOp new];
+    }]];
+    
+    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+                                                             @"s_foo": [NSNull null],
+                                                             @"b_true": @"N/A",
+                                                             @"i_42": @"N/A",
+                                                             @"d_4_2": @"N/A"
+                                                             };
+    
+    OPTLYVariation *variation = [_optimizely activate:@"ab_running_exp_audience_combo_not_foo" userId:@"test_user_1" attributes:userAttributes callback:^(NSError *error) {
+    }];
+    XCTAssertEqualObjects(nil, variation.variationKey);
+    
+    userAttributes = @{
+                       @"s_foo": @"not_foo",
+                       @"b_true": @"N/A",
+                       @"i_42": [NSNull null],
+                       @"d_4_2": @"N/A"
+                       };
+    
+    variation = [_optimizely activate:@"ab_running_exp_audience_combo_not_foo__and__not_42" userId:@"test_user_1" attributes:userAttributes callback:^(NSError *error) {
+    }];
+    XCTAssertEqualObjects(nil, variation.variationKey);
+}
+
 - (void)testActivateWithAttributesComplexAudienceMatch {
     
     NSDictionary<NSString *, NSObject *> *userAttributes = @{

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/TestData/audience_targeting.json
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/TestData/audience_targeting.json
@@ -1,0 +1,1634 @@
+{
+  "version": "4",
+  "rollouts": [],
+  "anonymizeIP": true,
+  "projectId": "10431130345",
+  "variables": [],
+  "featureFlags": [],
+  "experiments": [
+    {
+      "status": "Running",
+      "key": "ab_running_exp_single_exact_match_string_audience",
+      "layerId": "10420273888",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523121",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["10413101794"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523121",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977673"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_untargeted",
+      "layerId": "10420273889",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523122",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523122",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977674"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_exact_match",
+      "layerId": "10420273889",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523122",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101795", "20413101796", "20413101797" ,"20413101798"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523122",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "103909776741"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_exists_match",
+      "layerId": "10420273890",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523123",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101799", "20413101800", "20413101801" ,"20413101802"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523123",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977675"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_lt_43_match",
+      "layerId": "10420273891",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523124",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101803", "20413101804"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523124",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977676"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_gt_41_match",
+      "layerId": "10420273892",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523125",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101805", "20413101806"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523125",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977677"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_substring_match",
+      "layerId": "10420273893",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523126",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101807"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523126",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977678"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_gt_41_and_lt_43",
+      "layerId": "10420273894",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523127",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101808"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523127",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977679"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_exact_match_missing_value",
+      "layerId": "10420273895",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523128",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101810", "20413101811", "20413101812", "20413101813"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523128",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977680"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_s_foo_or_s_bar",
+      "layerId": "10420273896",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523129",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101814"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523129",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977681"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_b_true_or_i_lt_43",
+      "layerId": "10420273897",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523130",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101815"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523130",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977682"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_lt_4_3_match",
+      "layerId": "10420273898",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523131",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101804"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523131",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977683"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_gt_4_1_match",
+      "layerId": "10420273899",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523132",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101806"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523132",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977684"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_gt_4_1_and_lt_4_3",
+      "layerId": "10420273900",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523133",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101809"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523133",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977685"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_exact_match",
+      "layerId": "10420273901",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523134",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101816", "20413101817", "20413101818" ,"20413101819"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523134",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977686"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_s_foo_exists_match",
+      "layerId": "10420273902",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523135",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101820"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523135",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977687"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_b_true_exists_match",
+      "layerId": "10420273903",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523136",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101821"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523136",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977688"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_i_42_exists_match",
+      "layerId": "10420273904",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523137",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101822"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523137",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977689"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_d_4_2_exists_match",
+      "layerId": "10420273905",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523138",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101823"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523138",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977690"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_lt_43_match",
+      "layerId": "10420273906",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523139",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101824"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523139",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977691"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_lt_4_3_match",
+      "layerId": "10420273907",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523140",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101825"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523140",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977692"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_gt_41_match",
+      "layerId": "10420273908",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523141",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101826"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523141",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977693"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_gt_4_1_match",
+      "layerId": "10420273909",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523142",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101827"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523142",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977694"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_substring_match",
+      "layerId": "10420273910",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523143",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101828"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523143",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977695"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_gt_41_and_lt_43",
+      "layerId": "10420273911",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523144",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101829"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523144",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977696"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_gt_4_1_and_lt_4_3",
+      "layerId": "10420273912",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523145",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101830"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523145",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977697"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_invalid_attribute_type",
+      "layerId": "10420273913",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523146",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101831", "20413101832"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523146",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977698"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_unknown_match_type",
+      "layerId": "10420273914",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523147",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101833"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523147",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977699"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_missing_match_type",
+      "layerId": "10420273915",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523148",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101834"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523148",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977700"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_lt_match_null_value",
+      "layerId": "10420273916",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523149",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101835"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523149",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977701"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_lt_match_string_value",
+      "layerId": "10420273917",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523150",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101836"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523150",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977702"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_lt_match_missing_value",
+      "layerId": "10420273918",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523151",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101837"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523151",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977703"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_gt_match_null_value",
+      "layerId": "10420273919",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523152",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101838"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523151",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977704"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_gt_match_string_value",
+      "layerId": "10420273920",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523153",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101839"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523153",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977705"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_gt_match_missing_value",
+      "layerId": "10420273921",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523154",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101840"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523154",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977706"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_substring_match_missing_value",
+      "layerId": "10420273922",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523155",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101841"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523155",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977707"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_substring_match_null_value",
+      "layerId": "10420273923",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523156",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101842"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523156",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977708"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_substring_match_boolean_value",
+      "layerId": "10420273924",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523157",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101843"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523157",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977709"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_substring_match_number_value",
+      "layerId": "10420273925",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523158",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101844"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523158",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977710"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_exact_foo_and_42",
+      "layerId": "10420273926",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523159",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["and", "20413101795", "20413101797"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523159",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977711"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_exact_foo_or_42",
+      "layerId": "10420273927",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523160",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["or", "20413101795", "20413101797"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523160",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977712"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_exact_foo_and__42_or_4_2",
+      "layerId": "10420273928",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523161",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["and", "20413101795", ["or", "20413101797", "20413101798"]],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523161",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977713"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_exact_foo_or_true__and__42_or_4_2",
+      "layerId": "10420273929",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523162",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["and", ["or", "20413101795", "20413101796"], ["or", "20413101797", "20413101798"]],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523162",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977714"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_exact_foo_and_true__and__42_and_4_2",
+      "layerId": "10420273929",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523162",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["and", ["and", "20413101795", "20413101796"], ["and", "20413101797", "20413101798"]],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523162",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977715"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_exact_foo_and_true__or__42_and_4_2",
+      "layerId": "10420273930",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523163",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["or", ["and", "20413101795", "20413101796"], ["and", "20413101797", "20413101798"]],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523163",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977716"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_exact_foo_and_true_and_42_and_4_2",
+      "layerId": "10420273931",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523164",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["and", "20413101795", "20413101796", "20413101797", "20413101798"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523164",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977717"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_not_foo",
+      "layerId": "10420273932",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523165",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["not", "20413101795"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523165",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977718"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_not__foo_or_42",
+      "layerId": "10420273933",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523166",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["not", ["or", "20413101795", "20413101797"]],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523166",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977719"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_not__foo_and_42",
+      "layerId": "10420273934",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523167",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["not", ["and", "20413101795", "20413101797"]],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523167",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977720"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_not_foo__and__not_42",
+      "layerId": "10420273935",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523168",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["and", ["not", "20413101795"], ["not", "20413101797"]],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523168",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977721"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_not_foo__or__not_42",
+      "layerId": "10420273936",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523169",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["or", ["not", "20413101795"], ["not", "20413101797"]],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523169",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977722"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_empty_conditions",
+      "layerId": "10420273937",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523170",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": [],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523170",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977723"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_not_foo_with_additional_audience",
+      "layerId": "10420273938",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523170",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["not", "20413101795", "20413101797"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523170",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977724"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_with_exact_foo_match_audience_id_and_empty_audience_conditions",
+      "layerId": "10420273939",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523171",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["10413101794"],
+      "audienceConditions": [],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523171",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977725"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_untyped_audience_combo_exact_foo_and_bar",
+      "layerId": "10420273940",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523172",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["and", "10413101796", "10413101797"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523172",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977726"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_missing_operand_exact_foo_or_42",
+      "layerId": "10420273941",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523173",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["20413101795", "20413101797"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523173",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977727"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_leaf_root",
+      "layerId": "10420273942",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523174",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": "20413101795",
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523174",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977728"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_ids_unknown_audience_or_exact_foo",
+      "layerId": "10420273943",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523175",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["0000000000", "20413101795"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523175",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977729"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_unknown_audience_or_exact_foo",
+      "layerId": "10420273944",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523176",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["or", "0000000000", "20413101795"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523176",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977730"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_unknown_audience_and_exact_foo",
+      "layerId": "10420273945",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523177",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["and", "0000000000", "20413101795"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523177",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977731"
+    }
+  ],
+  "audiences": [
+    {
+      "id": "10413101794",
+      "conditions": "[\"and\", [\"or\", [\"or\", {\"type\": \"custom_attribute\", \"name\": \"string_attribute\", \"value\": \"exact_match\"}]]]",
+      "name": "untyped_single_condition_exact_string_match"
+    },
+    {
+      "id": "10413101795",
+      "_comment_about_condition_format": "Note: pre-3.0 Java SDKs cannot parse leaves at the root of this condition tree. App backend accommodates those SDKs by wrapping the leaves in parents. (OASIS-3718)",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_atribute\", \"match\": \"exact\", \"value\": \"$opt_dummy_value\"}",
+      "name": "untyped_single_dummy_condition"
+    },
+    {
+      "id": "10413101796",
+      "conditions": "[\"and\", [\"or\", [\"or\", {\"type\": \"custom_attribute\", \"name\": \"s_foo\", \"value\": \"foo\"}]]]",
+      "name": "untyped_single_condition_exact_foo_string_match"
+    },
+    {
+      "id": "10413101797",
+      "conditions": "[\"and\", [\"or\", [\"or\", {\"type\": \"custom_attribute\", \"name\": \"s_bar\", \"value\": \"bar\"}]]]",
+      "name": "untyped_single_condition_exact_bar_string_match"
+    },
+    {
+      "_comment": "Dummy audience that is overridden by a typedAudience with the same id",
+      "id": "20413101798",
+      "_comment_about_condition_format": "Note: pre-3.0 Java SDKs cannot parse leaves at the root of this condition tree. App backend accommodates those SDKs by wrapping the leaves in parents. (OASIS-3718)",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_atribute\", \"match\": \"exact\", \"value\": \"$opt_dummy_value\"}",
+      "name": "dummy_audience_overridden_by_typed_audience"
+    },
+    {
+      "_comment": "Dummy audience that is targeted by audienceIds for experiments with backwards-incompatible audienceConditions",
+      "id": "$opt_dummy_audience",
+      "conditions": "[\"and\", [\"or\", [\"or\", {\"type\": \"custom_attribute\", \"name\": \"string_attribute\", \"value\": \"exact_match\"}]]]",
+      "name": "dummy_audience"
+    }
+  ],
+  "typedAudiences": [
+    {
+      "id": "20413101795",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "exact", "value": "foo" } ] ] ],
+      "name": "single_condition_exact_string_match"
+    },
+    {
+      "id": "20413101796",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "b_true", "match": "exact", "value": true } ] ] ],
+      "name": "single_condition_exact_boolean_match"
+    },
+    {
+      "id": "20413101797",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "exact", "value": 42 } ] ] ],
+      "name": "single_condition_exact_int_match"
+    },
+    {
+      "id": "20413101798",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "exact", "value": 4.2 } ] ] ],
+      "name": "single_condition_exact_double_match"
+    },
+    {
+      "id": "20413101799",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "exists" } ] ] ],
+      "name": "single_condition_exists_string_match"
+    },
+    {
+      "id": "20413101800",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "b_true", "match": "exists" } ] ] ],
+      "name": "single_condition_exists_boolean_match"
+    },
+    {
+      "id": "20413101801",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "exists" } ] ] ],
+      "name": "single_condition_exists_int_match"
+    },
+    {
+      "id": "20413101802",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "exists" } ] ] ],
+      "name": "single_condition_exists_double_match"
+    },
+    {
+      "id": "20413101803",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "lt", "value": 43 } ] ] ],
+      "name": "single_condition_lt_int_match"
+    },
+    {
+      "id": "20413101804",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "lt", "value": 4.3 } ] ] ],
+      "name": "single_condition_lt_double_match"
+    },
+    {
+      "id": "20413101805",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "gt", "value": 41 } ] ] ],
+      "name": "single_condition_gt_int_match"
+    },
+    {
+      "id": "20413101806",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "gt", "value": 4.1 } ] ] ],
+      "name": "single_condition_gt_double_match"
+    },
+    {
+      "id": "20413101807",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "substring", "value": "foo" } ] ] ],
+      "name": "single_condition_substring_match"
+    },
+    {
+      "id": "20413101808",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "lt", "value": 43 } ] ], [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "gt", "value": 41 } ] ] ],
+      "name": "multiple_conditions_integer_range_match"
+    },
+    {
+      "id": "20413101809",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "lt", "value": 4.3 } ] ], [ "or", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "gt", "value": 4.1 } ] ] ],
+      "name": "multiple_conditions_double_range_match"
+    },
+    {
+      "id": "20413101810",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "exact" } ] ] ],
+      "name": "single_condition_exact_match_missing_value"
+    },
+    {
+      "id": "20413101811",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "b_true", "match": "exact" } ] ] ],
+      "name": "single_condition_exact_match_missing_value"
+    },
+    {
+      "id": "20413101812",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "exact" } ] ] ],
+      "name": "single_condition_exact_match_missing_value"
+    },
+    {
+      "id": "20413101813",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "exact" } ] ] ],
+      "name": "single_condition_exact_match_missing_value"
+    },
+    {
+      "id": "20413101814",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "exact", "value": "foo" }, { "type": "custom_attribute", "name": "s_bar", "match": "exact", "value": "bar" } ] ] ],
+      "name": "multiple_or_string_conditions_exact_match"
+    },
+    {
+      "id": "20413101815",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "b_true", "match": "exact", "value": true }, { "type": "custom_attribute", "name": "i_42", "match": "lt", "value": 43 } ] ] ],
+      "name": "multiple_or_conditions_mixed_types"
+    },
+    {
+      "id": "20413101816",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "exact", "value": "foo" } ] ] ] ],
+      "name": "negated_single_condition_exact_string_match"
+    },
+    {
+      "id": "20413101817",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "b_true", "match": "exact", "value": true } ] ] ] ],
+      "name": "negated_single_condition_exact_boolean_match"
+    },
+    {
+      "id": "20413101818",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "exact", "value": 42 } ] ] ] ],
+      "name": "negated_single_condition_exact_int_match"
+    },
+    {
+      "id": "20413101819",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "exact", "value": 4.2 } ] ] ] ],
+      "name": "negated_single_condition_exact_double_match"
+    },
+    {
+      "id": "20413101820",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "exists" } ] ] ] ],
+      "name": "negated_single_condition_exists_string_match"
+    },
+    {
+      "id": "20413101821",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "b_true", "match": "exists" } ] ] ] ],
+      "name": "negated_single_condition_exists_boolean_match"
+    },
+    {
+      "id": "20413101822",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "exists" } ] ] ] ],
+      "name": "negated_single_condition_exists_int_match"
+    },
+    {
+      "id": "20413101823",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "exists" } ] ] ] ],
+      "name": "negated_single_condition_exists_double_match"
+    },
+    {
+      "id": "20413101824",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "lt", "value": 43 } ] ] ] ],
+      "name": "negated_single_condition_lt_int_match"
+    },
+    {
+      "id": "20413101825",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "lt", "value": 4.3 } ] ] ] ],
+      "name": "negated_single_condition_lt_double_match"
+    },
+    {
+      "id": "20413101826",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "gt", "value": 41 } ] ] ] ],
+      "name": "negated_single_condition_gt_int_match"
+    },
+    {
+      "id": "20413101827",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "gt", "value": 4.1 } ] ] ] ],
+      "name": "negated_single_condition_gt_double_match"
+    },
+    {
+      "id": "20413101828",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "substring", "value": "foo" } ] ] ] ],
+      "name": "negated_single_condition_substring_match"
+    },
+    {
+      "id": "20413101829",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "lt", "value": 43 } ] ], [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "gt", "value": 41 } ] ] ] ] ],
+      "name": "negated_multiple_conditions_integer_range_match"
+    },
+    {
+      "id": "20413101830",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "lt", "value": 4.3 } ] ], [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "gt", "value": 4.1 } ] ] ] ] ],
+      "name": "negated_multiple_conditions_double_range_match"
+    },
+    {
+      "id": "20413101831",
+      "conditions": [ "and", [ "or", [ "or", { "type": "unknown", "name": "s_foo", "match": "exact" } ] ] ],
+      "name": "single_condition_exact_match_string_unknown_attribute_type"
+    },
+    {
+      "id": "20413101832",
+      "conditions": [ "and", [ "or", [ "or", { "name": "s_foo", "match": "exact" } ] ] ],
+      "name": "single_condition_exact_match_string_missing_attribute_type"
+    },
+    {
+      "id": "20413101833",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "unknown" } ] ] ],
+      "name": "single_condition_unknown_match_string"
+    },
+    {
+      "id": "20413101834",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "value": "foo" } ] ] ],
+      "name": "single_condition_missing_match_string"
+    },
+    {
+      "id": "20413101835",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "value": null, "match": "lt" } ] ] ],
+      "name": "single_condition_lt_match_null_value"
+    },
+    {
+      "id": "20413101836",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "value": "41", "match": "lt" } ] ] ],
+      "name": "single_condition_lt_match_string_value"
+    },
+    {
+      "id": "20413101837",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "lt" } ] ] ],
+      "name": "single_condition_lt_match_missing_value"
+    },
+    {
+      "id": "20413101838",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "value": null, "match": "gt" } ] ] ],
+      "name": "single_condition_gt_match_null_value"
+    },
+    {
+      "id": "20413101839",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "value": "41", "match": "gt" } ] ] ],
+      "name": "single_condition_gt_match_string_value"
+    },
+    {
+      "id": "20413101840",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "gt" } ] ] ],
+      "name": "single_condition_gt_match_missing_value"
+    },
+    {
+      "id": "20413101841",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "substring" } ] ] ],
+      "name": "single_condition_substring_match_missing_value"
+    },
+    {
+      "id": "20413101842",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "substring", "value": null } ] ] ],
+      "name": "single_condition_substring_match_null_value"
+    },
+    {
+      "id": "20413101843",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "substring", "value": true } ] ] ],
+      "name": "single_condition_substring_match_boolean_value"
+    },
+    {
+      "id": "20413101844",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "substring", "value": 400 } ] ] ],
+      "name": "single_condition_substring_match_number_value"
+    }
+  ],
+  "groups": [],
+  "attributes": [
+    {
+      "id": "10401066170",
+      "key": "string_attribute"
+    },
+    {
+      "id": "10401066171",
+      "key": "s_foo"
+    },
+    {
+      "id": "10401066172",
+      "key": "b_true"
+    },
+    {
+      "id": "10401066172",
+      "key": "i_42"
+    },
+    {
+      "id": "10401066173",
+      "key": "d_4_2"
+    },
+    {
+      "id": "10401066174",
+      "key": "s_bar"
+    },
+    {
+      "id": "10401066175",
+      "key": "b_false"
+    },
+    {
+      "id": "10401066176",
+      "key": "i_43"
+    },
+    {
+      "id": "10401066177",
+      "key": "d_4_3"
+    }
+  ],
+  "accountId": "10367498574",
+  "events": [
+    {
+      "experimentIds": [
+        "10390977673"
+      ],
+      "id": "10404198135",
+      "key": "event_single_targeted_exp"
+    },
+    {
+      "experimentIds": [
+        "10390977674"
+      ],
+      "id": "10404198136",
+      "key": "event_single_untargeted_exp"
+    }
+  ],
+  "revision": "241"
+}


### PR DESCRIPTION
1. For JSON parsing of Leaf condition, mark property 'type' as optional. Return null if leaf condition is evaluated with property 'type' null.
2. Fixed Audience Conditions Deserialization for empty array.
3. Fixed Audience Conditions Deserialization for a condition when leaf contains both audience id and a conditions array.
4. Fixed cases where Audience should be evaluated as null and was instead returning false.
5. Implemented test-cases for Audience Evaluation to fix issues detected on full-stack.