### PR TITLE
Support for Empty UserId (Activate and Track)

### DIFF
--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYBaseCondition.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYBaseCondition.m
@@ -52,7 +52,7 @@
     NSObject *userAttribute = [attributes objectForKey:self.name];
     NSNumber *success = NULL;
     
-    if ([self.value isKindOfClass:[NSString class]] && [userAttribute isKindOfClass:[NSString class]]) {
+    if ([self.value isValidStringType] && [userAttribute isValidStringType]) {
         success = [NSNumber numberWithBool:[self.value isEqual:userAttribute]];
     }
     else if ([self.value isValidNumericAttributeValue] && [userAttribute isValidNumericAttributeValue]) {

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
@@ -190,7 +190,7 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
         id tagValue = eventTags[tagKey];
         
         // only string, long, int, double, float, and booleans are supported
-        if (![tagValue isKindOfClass:[NSString class]] && ![tagValue isKindOfClass:[NSNumber class]]) {
+        if (![tagValue isValidStringType] && ![tagValue isKindOfClass:[NSNumber class]]) {
             [mutableEventTags removeObjectForKey:tagKey];
             NSString *logMessage = [NSString stringWithFormat:OPTLYLoggerMessagesEventTagValueInvalid, tagKey];
             [self.config.logger logMessage:logMessage withLevel:OptimizelyLogLevelDebug];

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventTagUtil.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventTagUtil.m
@@ -17,6 +17,7 @@
 #import "OPTLYEventTagUtil.h"
 #import "OPTLYEventMetric.h"
 #import "OPTLYLogger.h"
+#import "OPTLYNSObject+Validation.h"
 
 @implementation OPTLYEventTagUtil
 
@@ -93,7 +94,7 @@
             answer = nil;
             [logger logMessage:OPTLYLoggerMessagesRevenueValueInvalid withLevel:OptimizelyLogLevelWarning];
         }
-    } else if ([value isKindOfClass:[NSString class]]) {
+    } else if ([value isValidStringType]) {
         // cast strings to long long
         answer = @([(NSString*)value longLongValue]);
         [logger logMessage:[NSString stringWithFormat:OPTLYLoggerMessagesRevenueValueString, value] withLevel:OptimizelyLogLevelWarning];
@@ -138,7 +139,7 @@
                 [logger logMessage:[NSString stringWithFormat:OPTLYLoggerMessagesNumericValueInvalidFloat, value] withLevel:OptimizelyLogLevelWarning];
             }
         }
-    } else if ([value isKindOfClass:[NSString class]]) {
+    } else if ([value isValidStringType]) {
         // cast strings to double
         double doubleValue = [(NSString*)value doubleValue];
         if (isfinite(doubleValue)) {

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.h
@@ -21,6 +21,13 @@ NS_ASSUME_NONNULL_BEGIN
 @interface NSObject (Validation)
 
 /**
+ * Returns if object is a valid string type
+ *
+ * @returns A Bool whether object is a valid string type.
+ **/
+- (BOOL)isValidStringType;
+
+/**
  * Determines if object is a valid non-empty string type.
  *
  * @returns A NSString if object is valid string type, else return nil.

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYNSObject+Validation.m
@@ -19,9 +19,17 @@
 
 @implementation NSObject (Validation)
 
+- (BOOL)isValidStringType {
+    if (self) {
+        // check value is NSString
+        return [self isKindOfClass:[NSString class]];
+    }
+    return false;
+}
+
 - (nullable NSString *)getValidString {
     if (self) {
-        if ([self isKindOfClass:[NSString class]] && ![(NSString *)self isEqualToString:@""]) {
+        if ([self isValidStringType] && ![(NSString *)self isEqualToString:@""]) {
             return (NSString *)self;
         }
     }
@@ -49,7 +57,7 @@
 - (NSString *)getStringOrEmpty {
     NSString *string = @"";
     if (self) {
-        if ([self isKindOfClass:[NSString class]]) {
+        if ([self isValidStringType]) {
             string = [string stringByAppendingString:((NSString *)self)];
         }
     }
@@ -58,7 +66,7 @@
 
 - (nullable NSArray *)getValidAudienceConditionsArray {
     if(self) {
-        if ([self isKindOfClass:[NSString class]]) {
+        if ([self isValidStringType]) {
             //Check if string is a valid json
             NSError *error = nil;
             NSData *data = [(NSString *)self dataUsingEncoding:NSUTF8StringEncoding];
@@ -82,7 +90,7 @@
 
 - (nullable NSArray *)getValidConditionsArray {
     if(self) {
-        if ([self isKindOfClass:[NSString class]]) {
+        if ([self isValidStringType]) {
             NSError *error = nil;
             NSData *data = [(NSString *)self dataUsingEncoding:NSUTF8StringEncoding];
             NSArray *conditionsArray = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:&error];
@@ -100,7 +108,7 @@
             return false;
         }
         // check value is NSString
-        if ([self isKindOfClass:[NSString class]]) {
+        if ([self isValidStringType]) {
             return true;
         }
         // check value is Boolean
@@ -115,7 +123,7 @@
     return false;
 }
 
--(BOOL)isValidBooleanAttributeValue {
+- (BOOL)isValidBooleanAttributeValue {
     if (self) {
         // check value is NSNumber
         NSNumber *number = (NSNumber *)self;
@@ -126,7 +134,7 @@
     return false;
 }
 
--(BOOL)isValidNumericAttributeValue {
+- (BOOL)isValidNumericAttributeValue {
     if (self) {
         NSNumber *number = (NSNumber *)self;
         // check value is NSNumber

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYNotificationCenter.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYNotificationCenter.m
@@ -19,6 +19,7 @@
 #import "OPTLYLogger.h"
 #import "OPTLYExperiment.h"
 #import "OPTLYVariation.h"
+#import "OPTLYNSObject+Validation.h"
 #import <objc/runtime.h>
 
 NSString *const OPTLYNotificationExperimentKey = @"experiment";
@@ -149,7 +150,7 @@ NSString *const OPTLYNotificationLogEventParamsKey = @"logEventParams";
     
     NSString *userId = (NSString *)[args objectForKey:OPTLYNotificationUserIdKey];
     assert(userId);
-    assert([userId isKindOfClass:[NSString class]]);
+    assert([userId isValidStringType]);
     
     NSDictionary *attributes = (NSDictionary *)[args objectForKey:OPTLYNotificationAttributesKey];
     
@@ -178,11 +179,11 @@ NSString *const OPTLYNotificationLogEventParamsKey = @"logEventParams";
     
     NSString *eventKey = (NSString *)[args objectForKey:OPTLYNotificationEventKey];
     assert(eventKey);
-    assert([eventKey isKindOfClass:[NSString class]]);
+    assert([eventKey isValidStringType]);
     
     NSString *userId = (NSString *)[args objectForKey:OPTLYNotificationUserIdKey];
     assert(userId);
-    assert([userId isKindOfClass:[NSString class]]);
+    assert([userId isValidStringType]);
     
     NSDictionary *attributes = (NSDictionary *)[args objectForKey:OPTLYNotificationAttributesKey];
     if (attributes != nil && ![attributes isEqual:[NSNull null]]) {

--- a/OptimizelySDKCore/OptimizelySDKCore/Optimizely.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/Optimizely.m
@@ -123,7 +123,7 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
         return nil;
     }
     
-    if ([userId getValidString] == nil) {
+    if (![userId isValidStringType]) {
         NSError *error = [self handleErrorLogsForActivate:OPTLYLoggerMessagesUserIdInvalid ofLevel:OptimizelyLogLevelError];
         _callback(error);
         return nil;
@@ -434,7 +434,7 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
         return;
     }
     
-    if ([userId getValidString] == nil) {
+    if (![userId isValidStringType]) {
         [self handleErrorLogsForTrack:OPTLYLoggerMessagesUserIdInvalid ofLevel:OptimizelyLogLevelError];
         return;
     }

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
@@ -244,6 +244,14 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 
 # pragma mark - Integration Tests
 
+- (void)testOptimizelyActivateWithEmptyUserId {
+    OPTLYVariation *_variation = [self.optimizely activate:@"testExperimentMultivariate"
+                                                    userId:@""];
+    XCTAssertNotNil(_variation);
+    XCTAssertEqualObjects(@"Feorge", _variation.variationKey);
+}
+
+
 - (void)testOptimizelyActivateWithNoExperiment {
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"getActivatedVariation"];
     

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
@@ -1588,6 +1588,8 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     XCTAssertTrue([self.optimizely setForcedVariation:kExperimentKeyForFV
                                                userId:@""
                                          variationKey:kVariationKeyForFV]);
+    OPTLYVariation *variation = [self.optimizely getForcedVariation:kExperimentKeyForFV userId:@""];
+    XCTAssertEqualObjects(variation.variationKey, kVariationKeyForFV);
 }
 
 - (void)testSetForcedVariationWithInvalidExperimentKey

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
@@ -431,6 +431,28 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     [loggerMock stopMocking];
 }
 
+- (void)testOptimizelyTrackWithEmptyUserId {
+    
+    NSString *eventKey = @"testEvent";
+    __block NSString *_userId = nil;
+    __block NSString *notificationEventKey = nil;
+    __block NSDictionary<NSString *, NSObject *> *actualAttributes;
+    __block NSDictionary<NSString *, NSObject *> *actualEventTags;
+    
+    [self.optimizely.notificationCenter addTrackNotificationListener:^(NSString * _Nonnull eventKey, NSString * _Nonnull userId, NSDictionary<NSString *, NSObject *> * _Nonnull attributes, NSDictionary * _Nonnull eventTags, NSDictionary<NSString *,NSObject *> * _Nonnull event) {
+        _userId = userId;
+        notificationEventKey = eventKey;
+        actualAttributes = attributes;
+        actualEventTags = eventTags;
+    }];
+    
+    [self.optimizely track:eventKey userId:@""];
+    XCTAssertEqualObjects(@"", _userId);
+    XCTAssertEqual(eventKey, notificationEventKey);
+    XCTAssertEqualObjects(nil, actualAttributes);
+    XCTAssertEqualObjects(nil, actualEventTags);
+}
+
 - (void)testOptimizelyTrackWithInvalidEvent {
     
     NSString *invalidEventKey = @"invalid";


### PR DESCRIPTION
Added support in track and activate calls to accept empty user id as valid.