### PR TITLE
(Fix) fix audience combindations.

### DIFF
--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYExperiment.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYExperiment.m
@@ -52,6 +52,11 @@ NSString * const OPTLYExperimentStatusRunning = @"Running";
 }
 
 - (nullable NSNumber *)evaluateConditionsWithAttributes:(NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
+    if (self.audienceConditions != nil && self.audienceConditions.count > 0  && [self.audienceConditions[0] isKindOfClass:NSString.class]) {
+        NSError *err = nil;
+        NSArray *array = self.audienceConditions;
+        self.audienceConditions = [OPTLYCondition deserializeAudienceConditionsJSONArray:array error:&err];
+    }
     for (NSObject<OPTLYCondition> *condition in self.audienceConditions) {
         NSNumber *result = [condition evaluateConditionsWithAttributes:attributes projectConfig:config];
         if (result != NULL && [result boolValue] == true) {

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYExperiment.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYExperiment.m
@@ -41,8 +41,12 @@ NSString * const OPTLYExperimentStatusRunning = @"Running";
 }
 
 - (void)setAudienceConditionsWithNSString:(NSString *)string {
-    NSError *err = nil;
     NSArray *array = [string getValidAudienceConditionsArray];
+    [self setAudienceConditionsWithNSArray:array];
+}
+
+- (void)setAudienceConditionsWithNSArray:(NSArray *)array {
+    NSError *err = nil;
     self.audienceConditions = [OPTLYCondition deserializeAudienceConditionsJSONArray:array error:&err];
     
     if (err != nil) {
@@ -52,11 +56,7 @@ NSString * const OPTLYExperimentStatusRunning = @"Running";
 }
 
 - (nullable NSNumber *)evaluateConditionsWithAttributes:(NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
-    if (self.audienceConditions != nil && self.audienceConditions.count > 0  && [self.audienceConditions[0] isKindOfClass:NSString.class]) {
-        NSError *err = nil;
-        NSArray *array = self.audienceConditions;
-        self.audienceConditions = [OPTLYCondition deserializeAudienceConditionsJSONArray:array error:&err];
-    }
+
     for (NSObject<OPTLYCondition> *condition in self.audienceConditions) {
         NSNumber *result = [condition evaluateConditionsWithAttributes:attributes projectConfig:config];
         if (result != NULL && [result boolValue] == true) {


### PR DESCRIPTION
## Summary
- Problem when the audience combinations is an array of strings instead of string.  

added setupAudienceConditionsWithNSArray.  We keep withString because it is possible to have a single node which would be a audience id.

The "why", or other context.

