### PR TITLE
(fix):only trim user profile service if the number of experiments in the ma…

### DIFF
--- a/OptimizelySDKUserProfileService/OptimizelySDKUserProfileService/OPTLYUserProfileService.m
+++ b/OptimizelySDKUserProfileService/OptimizelySDKUserProfileService/OPTLYUserProfileService.m
@@ -165,6 +165,9 @@
         NSMutableDictionary *userProfileDict = [userProfileService[key] mutableCopy];
         NSDictionary * bucketMap = userProfileDict[@"experiment_bucket_map"];
         NSMutableDictionary *newBucketMap = [bucketMap mutableCopy];
+        if (bucketMap.count < 100) {
+            continue;
+        }
         for (NSString *exId in bucketMap.allKeys) {
             if (![validExperimentIds containsObject:exId]) {
                 [newBucketMap removeObjectForKey:exId];


### PR DESCRIPTION
…p is over 100

## Summary
- Problem occurs when a experiment is paused to change traffic allocation, it is removed from the datafile and subsequently removed from the ups.  This puts a cap so that if ups grows to over 100 experiments, try and trim the profile.

The "why", or other context.

## Test plan

## Issues
Fix 3943
