### PR TITLE
(feat): easy event tracking.  

### DIFF
--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2016,2018, Optimizely, Inc. and contributors                   *
+ * Copyright 2016-2019 Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.h
@@ -57,7 +57,6 @@ NS_ASSUME_NONNULL_END
  */
 - (nullable NSDictionary *)buildConversionEventForUser:(nonnull NSString *)userId
                                                  event:(nonnull OPTLYEvent *)event
-                                             decisions:(nonnull NSArray<NSDictionary *> *)decisions
                                              eventTags:(nullable NSDictionary *)eventTags
                                             attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes;
 @end

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2016-2019, Optimizely, Inc. and contributors                   *
+ * Copyright 2016,2018-2019, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2016,2018, Optimizely, Inc. and contributors                   *
+ * Copyright 2016-2019, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
@@ -70,7 +70,6 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
 
 -(NSDictionary *)buildConversionEventForUser:(NSString *)userId
                                        event:(OPTLYEvent *)event
-                                   decisions:(NSArray<NSDictionary *> *)decisions
                                    eventTags:(NSDictionary *)eventTags
                                   attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
 
@@ -80,7 +79,7 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
     
     NSDictionary *commonParams = [self createCommonParamsForUser:userId attributes:attributes];
     NSArray *conversionOnlyParams = [self createConversionParamsOfEvent:event userId:userId
-                                                              decisions:decisions eventTags:eventTags
+                                                              eventTags:eventTags
                                                              attributes:attributes];
     NSDictionary *conversionParams = [self createImpressionOrConversionParamsWithCommonParams:commonParams conversionOrImpressionOnlyParams:conversionOnlyParams];
     
@@ -99,6 +98,8 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
     commonParams[OPTLYEventParameterKeysVisitors] = @[visitor];
     commonParams[OPTLYEventParameterKeysProjectId] = [self.config.projectId getStringOrEmpty];
     commonParams[OPTLYEventParameterKeysAccountId] = [self.config.accountId getStringOrEmpty];
+    commonParams[OPTLYEventParameterKeysEnrichDecisions] = @(true);
+
     commonParams[OPTLYEventParameterKeysClientEngine] = [[self.config clientEngine] getStringOrEmpty];
     commonParams[OPTLYEventParameterKeysClientVersion] = [[self.config clientVersion] getStringOrEmpty];
     commonParams[OPTLYEventParameterKeysRevision] = [self.config.revision getStringOrEmpty];
@@ -142,7 +143,6 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
 
 - (NSArray *)createConversionParamsOfEvent:(OPTLYEvent *)event
                                     userId:(NSString *)userId
-                                 decisions:(NSArray<NSDictionary *> *)decisions
                                  eventTags:(NSDictionary *)eventTags
                                 attributes:(NSDictionary *)attributes {
     
@@ -175,7 +175,6 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
         }
     }
     
-    snapshot[OPTLYEventParameterKeysDecisions] = decisions;
     snapshot[OPTLYEventParameterKeysEvents] = @[eventDict];
     
     [conversionEventParams addObject:snapshot];

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
@@ -98,7 +98,7 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
     commonParams[OPTLYEventParameterKeysVisitors] = @[visitor];
     commonParams[OPTLYEventParameterKeysProjectId] = [self.config.projectId getStringOrEmpty];
     commonParams[OPTLYEventParameterKeysAccountId] = [self.config.accountId getStringOrEmpty];
-    commonParams[OPTLYEventParameterKeysEnrichDecisions] = @(true);
+    commonParams[OPTLYEventParameterKeysEnrichDecisions] = @YES;
 
     commonParams[OPTLYEventParameterKeysClientEngine] = [[self.config clientEngine] getStringOrEmpty];
     commonParams[OPTLYEventParameterKeysClientVersion] = [[self.config clientVersion] getStringOrEmpty];

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventParameterKeys.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventParameterKeys.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2016-2018, Optimizely, Inc. and contributors                   *
+ * Copyright 2016-2019, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventParameterKeys.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventParameterKeys.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 // --- Base Parameters ----
 extern NSString * const OPTLYEventParameterKeysAccountId;
 extern NSString * const OPTLYEventParameterKeysProjectId;
+extern NSString * const OPTLYEventParameterKeysEnrichDecisions;
 extern NSString * const OPTLYEventParameterKeysVisitors;
 extern NSString * const OPTLYEventParameterKeysAnonymizeIP;
 extern NSString * const OPTLYEventParameterKeysClientEngine;

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventParameterKeys.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventParameterKeys.m
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2016-2018, Optimizely, Inc. and contributors                   *
+ * Copyright 2016-2019, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -28,7 +28,7 @@ NSString * const OPTLYEventParameterKeysRevision                        = @"revi
 
 // --- Visitor Parameters ----
 NSString * const OPTLYEventParameterKeysSnapshots                       = @"snapshots";         // nonnull
-NSString * const OPTLYEventParameterKeysVisitorId                       = @"visitor_id";        // nonnull @"enrich_decisions"
+NSString * const OPTLYEventParameterKeysVisitorId                       = @"visitor_id";        // nonnull
 NSString * const OPTLYEventParameterKeysAttributes                      = @"attributes";
 
 // --- Snapshot Parameters ----

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventParameterKeys.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventParameterKeys.m
@@ -19,6 +19,7 @@
 // --- Base Parameters ----
 NSString * const OPTLYEventParameterKeysAccountId                       = @"account_id";        // nonnull
 NSString * const OPTLYEventParameterKeysProjectId                       = @"project_id";
+NSString * const OPTLYEventParameterKeysEnrichDecisions                 = @"enrich_decisions";
 NSString * const OPTLYEventParameterKeysVisitors                        = @"visitors";          // nonnull
 NSString * const OPTLYEventParameterKeysAnonymizeIP                     = @"anonymize_ip";
 NSString * const OPTLYEventParameterKeysClientEngine                    = @"client_name";
@@ -27,7 +28,7 @@ NSString * const OPTLYEventParameterKeysRevision                        = @"revi
 
 // --- Visitor Parameters ----
 NSString * const OPTLYEventParameterKeysSnapshots                       = @"snapshots";         // nonnull
-NSString * const OPTLYEventParameterKeysVisitorId                       = @"visitor_id";        // nonnull
+NSString * const OPTLYEventParameterKeysVisitorId                       = @"visitor_id";        // nonnull @"enrich_decisions"
 NSString * const OPTLYEventParameterKeysAttributes                      = @"attributes";
 
 // --- Snapshot Parameters ----

--- a/OptimizelySDKCore/OptimizelySDKCore/Optimizely.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/Optimizely.m
@@ -447,17 +447,8 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
         return;
     }
     
-    NSArray *decisions = [self decisionsFor:event userId:userId attributes:attributes];
-    
-    if ([decisions getValidArray] == nil) {
-        NSString *logMessage = [NSString stringWithFormat:OPTLYLoggerMessagesConversionFailure, eventKey];
-        [self handleErrorLogsForTrack:logMessage ofLevel:OptimizelyLogLevelInfo];
-        return;
-    }
-    
     NSDictionary *conversionEventParams = [self.eventBuilder buildConversionEventForUser:userId
                                                                                    event:event
-                                                                               decisions:decisions
                                                                                eventTags:eventTags
                                                                               attributes:attributes];
     if ([conversionEventParams getValidDictionary] == nil) {

--- a/OptimizelySDKCore/OptimizelySDKCore/Optimizely.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/Optimizely.m
@@ -900,57 +900,6 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
     return variation;
 }
 
-/**
- Helper method to retrieve decisions for the user from the provided event.
-
- @param event The event which needs to be recorded.
- @param userId Id for user.
- @param attributes The user's attributes.
- @return Array of dictionaries containing valid experiment Ids, variation Ids and layer Ids into which the user is bucketed.
- */
-- (NSArray<NSDictionary *> *)decisionsFor:(OPTLYEvent *)event
-                                   userId:(NSString *)userId
-                               attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
-    
-    NSArray *experimentIds = event.experimentIds;
-    
-    if ([experimentIds count] == 0) {
-        NSString *logMessage = [NSString stringWithFormat:OPTLYLoggerMessagesTrackEventNoAssociation, event.eventKey];
-        [self handleErrorLogsForTrack:logMessage ofLevel:OptimizelyLogLevelDebug];
-        return nil;
-    }
-    
-    NSMutableArray *decisions = [NSMutableArray new];
-    
-    for (NSString *experimentId in experimentIds) {
-        OPTLYExperiment *experiment = [self.config getExperimentForId:experimentId];
-        
-        // if the experiment is nil, then it is not part of the project's list of experiments
-        if (!experiment) {
-            NSString *logMessage = [NSString stringWithFormat:OPTLYLoggerMessagesTrackExperimentNoAssociation, experiment.experimentKey, event.eventKey];
-            [self handleErrorLogsForTrack:logMessage ofLevel:OptimizelyLogLevelDebug];
-            continue;
-        }
-        
-        // bucket user into a variation
-        OPTLYVariation *variation = [self variation:experiment.experimentKey userId:userId attributes:attributes];
-        
-        // if the variation is nil, then experiment should not be tracked
-        if (!variation) {
-            NSString *logMessage = [NSString stringWithFormat:OPTLYLoggerMessagesTrackExperimentNotTracked, userId, experiment.experimentKey];
-            [self handleErrorLogsForTrack:logMessage ofLevel:OptimizelyLogLevelDebug];
-            continue;
-        }
-        
-        NSMutableDictionary *decision = [NSMutableDictionary new];
-        decision[OPTLYEventParameterKeysDecisionCampaignId]         = [experiment.layerId getStringOrEmpty];
-        decision[OPTLYEventParameterKeysDecisionExperimentId]       = experiment.experimentId;
-        decision[OPTLYEventParameterKeysDecisionVariationId]        = variation.variationId;
-        [decisions addObject:decision];
-    }
-    return decisions;
-}
-                                      
 + (BOOL)isEmptyArray:(NSObject*)array {
     return (!array
             || ![array isKindOfClass:[NSArray class]]

--- a/OptimizelySDKCore/OptimizelySDKCore/Optimizely.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/Optimizely.m
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2017-2018, Optimizely, Inc. and contributors                   *
+ * Copyright 2017-2019, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYEventBuilderTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYEventBuilderTest.m
@@ -156,10 +156,8 @@ typedef enum : NSUInteger {
 #pragma mark - Test BuildConversionTicket:... Audiences
 
 - (void)testBuildConversionTicketWithNoAudience {
-    NSArray *decisions = [self.optimizely decisionsFor:eventWithoutAudience userId:kUserId attributes:nil];
     NSDictionary *params = [self.eventBuilder buildConversionEventForUser:kUserId
                                                                     event:eventWithoutAudience
-                                                                decisions:decisions
                                                                 eventTags:nil
                                                                attributes:nil];
     
@@ -175,10 +173,8 @@ typedef enum : NSUInteger {
 }
 
 - (void)testBuildConversionTicketWithValidAudience {
-    NSArray *decisions = [self.optimizely decisionsFor:eventWithAudience userId:kUserId attributes:self.attributes];
     NSDictionary *params = [self.eventBuilder buildConversionEventForUser:kUserId
                                                                     event:eventWithAudience
-                                                                decisions:decisions
                                                                 eventTags:nil
                                                                attributes:self.attributes];
     
@@ -201,26 +197,20 @@ typedef enum : NSUInteger {
 {
     // check without attributes that satisfy audience requirement
     NSDictionary *attributes = @{@"browser_type":@"chrome"};
-    NSArray *decisions = [self.optimizely decisionsFor:eventWithAudience userId:kUserId attributes:attributes];
     NSDictionary *conversionTicket = [self.eventBuilder buildConversionEventForUser:kUserId
                                                                               event:eventWithAudience
-                                                                          decisions:decisions
                                                                           eventTags:nil
                                                                          attributes:attributes];
     
     XCTAssertNotNil(conversionTicket, @"Conversion ticket should not be nil.");
     NSDictionary *visitor = conversionTicket[OPTLYEventParameterKeysVisitors][0];
     NSDictionary *snapshot = visitor[OPTLYEventParameterKeysSnapshots][0];
-    decisions = snapshot[OPTLYEventParameterKeysDecisions];
-    XCTAssertEqual([decisions count], 0, @"Conversion ticket should not have any decision");
 }
 
 - (void)testBuildConversionTicketWithExperimentNotRunning {
     OPTLYEvent *event = [self.config getEventForKey:kEventWithExperimentNotRunningName];
-    NSArray *decisions = [self.optimizely decisionsFor:event userId:kUserId attributes:nil];
     NSDictionary *conversionTicket = [self.eventBuilder buildConversionEventForUser:kUserId
                                                                               event:event
-                                                                          decisions:decisions
                                                                           eventTags:nil
                                                                          attributes:nil];
     
@@ -228,16 +218,14 @@ typedef enum : NSUInteger {
     XCTAssertNotNil(conversionTicket, @"Conversion ticket should not be nil.");
     NSDictionary *visitor = conversionTicket[OPTLYEventParameterKeysVisitors][0];
     NSDictionary *snapshot = visitor[OPTLYEventParameterKeysSnapshots][0];
-    decisions = snapshot[OPTLYEventParameterKeysDecisions];
+    NSDictionary *decisions = snapshot[OPTLYEventParameterKeysDecisions];
     XCTAssertEqual([decisions count], 0, @"Conversion ticket should not have any decision");
 }
 
 - (void)testBuildConversionTicketWithInvalidExperiment {
     OPTLYEvent *event = [self.config getEventForKey:kEventWithInvalidExperimentName];
-    NSArray *decisions = [self.optimizely decisionsFor:event userId:kUserId attributes:nil];
     NSDictionary *conversionTicket = [self.eventBuilder buildConversionEventForUser:kUserId
                                                                               event:event
-                                                                          decisions:decisions
                                                                           eventTags:nil
                                                                          attributes:nil];
     
@@ -245,17 +233,15 @@ typedef enum : NSUInteger {
     XCTAssertNotNil(conversionTicket, @"Conversion ticket should not be nil.");
     NSDictionary *visitor = conversionTicket[OPTLYEventParameterKeysVisitors][0];
     NSDictionary *snapshot = visitor[OPTLYEventParameterKeysSnapshots][0];
-    decisions = snapshot[OPTLYEventParameterKeysDecisions];
+    NSDictionary *decisions = snapshot[OPTLYEventParameterKeysDecisions];
     XCTAssertEqual([decisions count], 0, @"Conversion ticket should not have any decision");
 }
 
 - (void)testBuildConversionTicketWithNoConfig {
     self.config = nil;
     self.eventBuilder = [[OPTLYEventBuilderDefault alloc] initWithConfig:self.config];
-    NSArray *decisions = [self.optimizely decisionsFor:eventWithAudience userId:kUserId attributes:self.attributes];
     NSDictionary *conversionTicket = [self.eventBuilder buildConversionEventForUser:kUserId
                                                                               event:eventWithAudience
-                                                                          decisions:decisions
                                                                           eventTags:nil
                                                                          attributes:self.attributes];
     
@@ -679,10 +665,8 @@ typedef enum : NSUInteger {
 - (void)testBuildConversionTicketWithAnonymizeIPFalse {
     OPTLYProjectConfig *config = [self setUpForAnonymizeIPFalse];
     OPTLYEventBuilderDefault *eventBuilder = [[OPTLYEventBuilderDefault alloc] initWithConfig:config];
-    NSArray *decisions = [self.optimizely decisionsFor:eventWithoutAudience userId:kUserId attributes:nil];
     NSDictionary *params = [eventBuilder buildConversionEventForUser:kUserId
                                                                event:eventWithoutAudience
-                                                           decisions:decisions
                                                            eventTags:nil
                                                           attributes:nil];
     
@@ -694,10 +678,8 @@ typedef enum : NSUInteger {
 
 - (void)testCreateConversionEventWithEmptyAttributeValue {
     NSMutableDictionary *attributes = [NSMutableDictionary dictionaryWithDictionary:@{kAttributeKeyBrowserType : @""}];
-    NSArray *decisions = [self.optimizely decisionsFor:eventWithoutAudience userId:kUserId attributes:attributes];
     NSDictionary *params = [self.eventBuilder buildConversionEventForUser:kUserId
                                                                     event:eventWithoutAudience
-                                                                decisions:decisions
                                                                 eventTags:nil
                                                                attributes:attributes];
     
@@ -724,11 +706,9 @@ typedef enum : NSUInteger {
     NSData *data = [NSJSONSerialization dataWithJSONObject:datafile options:0 error:NULL];
     self.config = [[OPTLYProjectConfig alloc] initWithDatafile:data];
     self.eventBuilder = [[OPTLYEventBuilderDefault alloc] initWithConfig:self.config];
-    NSArray *decisions = [self.optimizely decisionsFor:eventWithoutAudience userId:kUserId attributes:self.attributes];
     
     NSDictionary *params = [self.eventBuilder buildConversionEventForUser:kUserId
                                                                     event:eventWithoutAudience
-                                                                decisions:decisions
                                                                 eventTags:nil
                                                                attributes:self.attributes];
     
@@ -810,11 +790,9 @@ typedef enum : NSUInteger {
     NSData *data = [NSJSONSerialization dataWithJSONObject:datafile options:0 error:NULL];
     self.config = [[OPTLYProjectConfig alloc] initWithDatafile:data];
     self.eventBuilder = [[OPTLYEventBuilderDefault alloc] initWithConfig:self.config];
-    NSArray *decisions = [self.optimizely decisionsFor:eventWithAudience userId:kUserId attributes:self.attributes];
     
     NSDictionary *params = [self.eventBuilder buildConversionEventForUser:kUserId
                                                                     event:eventWithAudience
-                                                                decisions:decisions
                                                                 eventTags:nil
                                                                attributes:self.attributes];
     
@@ -835,11 +813,9 @@ typedef enum : NSUInteger {
     NSData *data = [NSJSONSerialization dataWithJSONObject:datafile options:0 error:NULL];
     self.config = [[OPTLYProjectConfig alloc] initWithDatafile:data];
     self.eventBuilder = [[OPTLYEventBuilderDefault alloc] initWithConfig:self.config];
-    NSArray *decisions = [self.optimizely decisionsFor:eventWithAudience userId:kUserId attributes:self.attributes];
     
     NSDictionary *params = [self.eventBuilder buildConversionEventForUser:kUserId
                                                                     event:eventWithAudience
-                                                                decisions:decisions
                                                                 eventTags:nil
                                                                attributes:self.attributes];
     
@@ -962,10 +938,8 @@ typedef enum : NSUInteger {
     // Common subroutine for many of the testBuildEventXxx test methods.
     // Generally, a testBuildEventXxx should make at most one call
     // to commonBuildConversionTicketTest:sentEventTags:sentTags: .
-    NSArray *decisions = [self.optimizely decisionsFor:eventWithAudience userId:kUserId attributes:self.attributes];
     NSDictionary *params = [self.eventBuilder buildConversionEventForUser:kUserId
                                                                     event:eventWithAudience
-                                                                decisions:decisions
                                                                 eventTags:eventTags
                                                                attributes:self.attributes];
     [self.attributes addEntriesFromDictionary:self.reservedAttributes];
@@ -1062,22 +1036,7 @@ typedef enum : NSUInteger {
     
     // check conversion if payload available
     XCTAssertNotNil(params, @"Invalid Conversion ticket");
-    
-    NSArray *decisions = params[OPTLYEventParameterKeysDecisions];
-    
-    XCTAssertGreaterThan([decisions count], 0, @"Didn't find any decision");
-    XCTAssertGreaterThan([experimentKeys count], 0, @"Didn't find any experiment key");
-    
-    for (int i=0; i < [decisions count]; i++) {
-        NSDictionary *decision = decisions[i];
-        OPTLYExperiment *experiment = [config getExperimentForId:experimentKeys[i]];
-        OPTLYVariation *bucketedVariation = [config getVariationForExperiment:experiment.experimentKey
-                                                                       userId:userId
-                                                                   attributes:attributes
-                                                                     bucketer:bucketer];
-        [self checkDecision:decision campaignId:experiment.layerId experimentId:experiment.experimentId variationId:bucketedVariation.variationId];
-    }
-    
+        
     NSArray *events = params[OPTLYEventParameterKeysEvents];
     XCTAssertGreaterThan([events count], 0, @"Didn't find any event");
     
@@ -1189,6 +1148,10 @@ typedef enum : NSUInteger {
     NSString *clientVersion = params[OPTLYEventParameterKeysClientVersion];
     XCTAssert([clientVersion isEqualToString:[self.config clientVersion]], @"Incorrect client version.");
     
+    // check enrich_decisions
+    NSNumber *enrich = params[OPTLYEventParameterKeysEnrichDecisions];
+    XCTAssert([enrich boolValue] == true, @"Incorrect value for enrich decisions.");
+
     // check anonymizeIP
     NSNumber *anonymizeIP = params[OPTLYEventParameterKeysAnonymizeIP];
     XCTAssert([anonymizeIP boolValue] == true, @"Incorrect value for IP anonymization.");

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
@@ -480,8 +480,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     }]];
     [optimizely track:eventWithNoExerimentKey userId:kUserId attributes:self.attributes];
     
-    NSString *logMessage = [NSString stringWithFormat:OPTLYLoggerMessagesTrackEventNoAssociation, eventWithNoExerimentKey];
-    //OCMVerify([loggerMock logMessage:logMessage withLevel:OptimizelyLogLevelDebug]);
+    [loggerMock verify];
     [loggerMock stopMocking];
 }
 
@@ -1385,8 +1384,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
         builder.errorHandler = [OPTLYErrorHandlerNoOp new];
     }]];
     [optimizely track:eventId userId:userId attributes:attributes];
-    NSString *logMessage = [NSString stringWithFormat:OPTLYLoggerMessagesConversionFailure, eventId];
-    //OCMVerify([loggerMock logMessage:logMessage withLevel:OptimizelyLogLevelInfo]);
+    [loggerMock verify];
     [loggerMock stopMocking];
 }
 
@@ -1625,8 +1623,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     id loggerMock = OCMPartialMock((OPTLYLoggerDefault *)self.optimizelyTypedAudience.logger);
     
     [self.optimizelyTypedAudience track:@"user_signed_up" userId:@"test_user" attributes:userAttributes];
-    NSString *logMessage = [NSString stringWithFormat:OPTLYLoggerMessagesConversionFailure, @"user_signed_up"];
-    //OCMVerify([loggerMock logMessage:logMessage withLevel:OptimizelyLogLevelInfo]);
+    [loggerMock verify];
     [loggerMock stopMocking];
 }
 

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
@@ -481,7 +481,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     [optimizely track:eventWithNoExerimentKey userId:kUserId attributes:self.attributes];
     
     NSString *logMessage = [NSString stringWithFormat:OPTLYLoggerMessagesTrackEventNoAssociation, eventWithNoExerimentKey];
-    OCMVerify([loggerMock logMessage:logMessage withLevel:OptimizelyLogLevelDebug]);
+    //OCMVerify([loggerMock logMessage:logMessage withLevel:OptimizelyLogLevelDebug]);
     [loggerMock stopMocking];
 }
 
@@ -1386,7 +1386,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     }]];
     [optimizely track:eventId userId:userId attributes:attributes];
     NSString *logMessage = [NSString stringWithFormat:OPTLYLoggerMessagesConversionFailure, eventId];
-    OCMVerify([loggerMock logMessage:logMessage withLevel:OptimizelyLogLevelInfo]);
+    //OCMVerify([loggerMock logMessage:logMessage withLevel:OptimizelyLogLevelInfo]);
     [loggerMock stopMocking];
 }
 
@@ -1626,7 +1626,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     
     [self.optimizelyTypedAudience track:@"user_signed_up" userId:@"test_user" attributes:userAttributes];
     NSString *logMessage = [NSString stringWithFormat:OPTLYLoggerMessagesConversionFailure, @"user_signed_up"];
-    OCMVerify([loggerMock logMessage:logMessage withLevel:OptimizelyLogLevelInfo]);
+    //OCMVerify([loggerMock logMessage:logMessage withLevel:OptimizelyLogLevelInfo]);
     [loggerMock stopMocking];
 }
 


### PR DESCRIPTION
## Summary
Event builder change.
- Always pass "enrich_decisions" as true
- Only pass in decisions for impression event.
One byproduct is we do not filter the event anymore so we do not get a log message if the event is not part of any experiment.  We also send the event when it is not part of any experiment which is different behaviour.  

## Test plan
Added a test that makes sure enhance_decisions is set
## Issues
- We are losing logging and always sending an event which is different behaviour that previously. 
