### PR TITLE
(fix): performance problem with sendEvent.

### DIFF
--- a/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher/OPTLYEventDispatcher.m
+++ b/OptimizelySDKEventDispatcher/OptimizelySDKEventDispatcher/OPTLYEventDispatcher.m
@@ -96,6 +96,16 @@ dispatch_queue_t flushEventsQueue()
     return _flushEventsQueue;
 }
 
+dispatch_queue_t queueEventQueue()
+{
+    static dispatch_queue_t _queueEventsQueue = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _queueEventsQueue = dispatch_queue_create("com.Optimizely.QueueEvents", DISPATCH_QUEUE_SERIAL);
+    });
+    return _queueEventsQueue;
+}
+
 dispatch_queue_t dispatchEventQueue()
 {
     static dispatch_queue_t _dispatchEventQueue = nil;
@@ -168,12 +178,17 @@ dispatch_queue_t dispatchEventQueue()
 # pragma mark - Dispatch Events
 - (void)dispatchImpressionEvent:(nonnull NSDictionary *)params
                        callback:(nullable OPTLYEventDispatcherResponse)callback {
-    [self dispatchNewEvent:params backoffRetry:YES eventType:OPTLYDataStoreEventTypeImpression callback:callback];
+    dispatch_async(queueEventQueue(), ^{
+        [self dispatchNewEvent:params backoffRetry:YES eventType:OPTLYDataStoreEventTypeImpression callback:callback];
+    });
+    
 }
 
 - (void)dispatchConversionEvent:(nonnull NSDictionary *)params
                        callback:(nullable OPTLYEventDispatcherResponse)callback {
-    [self dispatchNewEvent:params backoffRetry:YES eventType:OPTLYDataStoreEventTypeConversion callback:callback];
+    dispatch_async(queueEventQueue(), ^{
+        [self dispatchNewEvent:params backoffRetry:YES eventType:OPTLYDataStoreEventTypeConversion callback:callback];
+    });
 }
 
 


### PR DESCRIPTION
## Summary
- The problem is that anytime you call activate or track on the main thread, we are causing problems by saving to sqlite.  The solution is to create a queueQueue to queue up these events.  This issue was visible in our demo app since it called track in response to a button click (probably done often).
The "why", or other context.

## Test plan
Tested E2E on my own projects.
## Issues
- 349 https://github.com/optimizely/objective-c-sdk/issues/349
- 276 https://github.com/optimizely/objective-c-sdk/issues/276