### PR TITLE
fix(emptybucketingid): Empty bucketing id should be acceptable.

### DIFF
--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYDecisionService.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYDecisionService.m
@@ -166,9 +166,9 @@
     // in place of the userID for the murmur hash key
     
     if (attributes != nil) {
-        NSString *validBucketingId = [attributes[OptimizelyBucketId] getValidString];
-        if (validBucketingId != nil) {
-            bucketingId = validBucketingId;
+        BOOL isValidStringType = [attributes[OptimizelyBucketId] isValidStringType];
+        if (isValidStringType) {
+            bucketingId = [attributes[OptimizelyBucketId] getStringOrEmpty];
             [self.config.logger logMessage:[NSString stringWithFormat:OPTLYLoggerMessagesDecisionServiceSettingTheBucketingID,
                                             bucketingId]
                                  withLevel:OptimizelyLogLevelDebug];

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYDecisionServiceTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYDecisionServiceTest.m
@@ -466,6 +466,18 @@ static NSString * const kFeatureFlagNoBucketedRuleRolloutKey = @"booleanSingleVa
                    kExperimentWithAudienceVariationKey, variation.variationKey);
 }
 
+- (void)testGetVariationWithEmptyBucketingId {
+    OPTLYExperiment *experiment = [self.config getExperimentForKey:kExperimentNoAudienceKey];
+    OPTLYVariation *variation = [self.decisionService getVariation:kUserId experiment:experiment attributes:nil];
+    
+    XCTAssertNotNil(variation, @"Get variation");
+    
+    NSDictionary *attributes = @{OptimizelyBucketId: @""};
+    OPTLYVariation *variationWithEmptyBucketingId = [self.decisionService getVariation:kUserId experiment:experiment attributes:attributes];
+    
+    XCTAssertNotEqual(variation.variationKey,variationWithEmptyBucketingId.variationKey);
+}
+
 - (void)testGetVariationAcceptAllTypeAttributes {
     
     OPTLYExperiment *experiment = [self.config getExperimentForKey:kExperimentNoAudienceKey];


### PR DESCRIPTION
## Summary
Empty bucketing ID should be acceptable for all `getVariation`, `getFeatureForRollout`, `getVariationForFeatureGroup`
## Test plan
Unit test added.
