### PR TITLE
fix: up integration test api timeout.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ jobs:
       env:
         - SDK=objective-c
         - BUILD_NUMBER=$TRAVIS_BUILD_NUMBER
+        - API_CALL_TIMEOUT=40000
       cache: false
       before_install: skip
       install:


### PR DESCRIPTION
## Summary 
- Increases the timeout we set for API calls in the Compatibility suite test because 30s is not enough for a lot of scenarios.

