### PR TITLE
(fix):update readme to include a note about using thread safe sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ up an Optimizely X project and start using the SDK.
  
 Please note below that _\<platform\>_ is used to represent the platform on which you are building your app. Currently, we support ```iOS``` and ```tvOS``` platforms.
 
+**note: if you or another framework are using sqlite, then you should probably add compiler options for thead safe sqlite: SQLITE_THREADSAFE=1
+https://www.sqlite.org/threadsafe.html
+
 #### Cocoapod 
 1. Add the following lines to the _Podfile_:<pre>
     ```use_frameworks!```


### PR DESCRIPTION
## Summary
- SQLite is not compiled thread safe by default.  You need to add a compiler option.  Added this to the notes if you want sqlite thread safe.

The "why", or other context.

Related to issue recently closed #361 #360 