### PR TITLE
(fix) add a cast to nsobject in order to avoid a build error in objective-c…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ jobs:
       env:
         - SDK=objective-c
         - BUILD_NUMBER=$TRAVIS_BUILD_NUMBER
+        - TESTAPP_TAG=master
       cache: false
       before_install: skip
       install:

--- a/OptimizelySDKShared/OptimizelySDKShared/OPTLYManagerBase.m
+++ b/OptimizelySDKShared/OptimizelySDKShared/OPTLYManagerBase.m
@@ -86,8 +86,11 @@ NSString * _Nonnull const OptimizelyBundleDatafileFileTypeExtension = @"json";
 //#pragma clang diagnostic push
 //#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
                 @try {
+                    // cast to NSObject.  If the user profile service is not the default service, then an exception will be thrown when trying to access this selector.
                     IMP imp = [((NSObject *)(self.userProfileService)).class instanceMethodForSelector:selector];
+                    // cast the function
                     void (*func)(id, SEL, NSArray *) = (void *)imp;
+                    // call it.
                     func(self.userProfileService, selector, ids);
                 }
                 @catch(NSException *e) {

--- a/OptimizelySDKShared/OptimizelySDKShared/OPTLYManagerBase.m
+++ b/OptimizelySDKShared/OptimizelySDKShared/OPTLYManagerBase.m
@@ -86,7 +86,7 @@ NSString * _Nonnull const OptimizelyBundleDatafileFileTypeExtension = @"json";
 //#pragma clang diagnostic push
 //#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
                 @try {
-                    IMP imp = [self.userProfileService.class instanceMethodForSelector:selector];
+                    IMP imp = [((NSObject *)(self.userProfileService)).class instanceMethodForSelector:selector];
                     void (*func)(id, SEL, NSArray *) = (void *)imp;
                     func(self.userProfileService, selector, ids);
                 }


### PR DESCRIPTION
…. Swift works fine. :/

## Summary
- Cast the user profile service which is an id (a objective-c object) but not necessarily a NSObject derived object.  In Objective-C projects, it fails to compile.  In Swift projects, it works fine.

## Test plan
Created test project in objective-c.  
Unit tests are in objective-c but did not fail.  Possibly because of bridge header?
## Issues
#378 
