### PR TITLE
(fix): make all changes for using id instead of NSObject *

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,7 +173,7 @@ To learn more about Feature Management, read our [knowledge base article introdu
 - (NSNumber *)getFeatureVariableDouble:(nullable NSString *)featureKey
                        variableKey:(nullable NSString *)variableKey
                             userId:(nullable NSString *)userId
-                        attributes:(nullable NSDictionary<NSString *, NSString *> *)attributes;
+                        attributes:(nullable NSDictionary<NSString *, id> *)attributes;
 - (NSNumber *)getFeatureVariableInteger:(nullable NSString *)featureKey
                      variableKey:(nullable NSString *)variableKey
                           userId:(nullable NSString *)userId

--- a/OptimizelyDemoApp/AppDelegate.swift
+++ b/OptimizelyDemoApp/AppDelegate.swift
@@ -125,7 +125,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
             })
 #endif
-            let variation = optimizelyClient?.activate((self?.experimentKey)!, userId: (self?.userId)!)
+            let attributes = ["browser_number": 7]
+            let variation = optimizelyClient?.activate((self?.experimentKey)!, userId: (self?.userId)!, attributes: attributes)
+            
             
             if let experiments = optimizelyClient?.optimizely?.config?.experiments {
                 for experiment in experiments {

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYAudience.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYAudience.m
@@ -64,7 +64,7 @@
     }
 }
 
-- (nullable NSNumber *)evaluateConditionsWithAttributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
+- (nullable NSNumber *)evaluateConditionsWithAttributes:(nullable NSDictionary<NSString *, id> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
     NSObject<OPTLYCondition> *condition = (NSObject<OPTLYCondition> *)[self.conditions firstObject];
     if (condition) {
         // Log Audience Evaluation Started

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYAudienceBaseCondition.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYAudienceBaseCondition.m
@@ -26,7 +26,7 @@
     return [jsonData isKindOfClass:[NSString class]];
 }
 
-- (nullable NSNumber *)evaluateConditionsWithAttributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
+- (nullable NSNumber *)evaluateConditionsWithAttributes:(nullable NSDictionary<NSString *, id> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
     if (attributes == nil) {
         // if the user did not pass in attributes, return false
         return [NSNumber numberWithBool:false];

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYBaseCondition.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYBaseCondition.m
@@ -52,7 +52,7 @@
     return [jsonData isKindOfClass:[NSDictionary class]];
 }
 
-- (nullable NSNumber *)evaluateMatchTypeExact:(NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
+- (nullable NSNumber *)evaluateMatchTypeExact:(NSDictionary<NSString *, id> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
     // check if user attributes contain a value that is of similar class type to our value and also equals to our value, else return Null
     
     // check if condition value is invalid
@@ -100,12 +100,12 @@
     return NULL;
 }
 
-- (nullable NSNumber *)evaluateMatchTypeExist:(NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
+- (nullable NSNumber *)evaluateMatchTypeExist:(NSDictionary<NSString *, id> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
     // check if user attributes contain our name as a key to a Non nullable object
     return [NSNumber numberWithBool:([attributes objectForKey:self.name] && ![attributes[self.name] isKindOfClass:[NSNull class]])];
 }
 
-- (nullable NSNumber *)evaluateMatchTypeSubstring:(NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
+- (nullable NSNumber *)evaluateMatchTypeSubstring:(NSDictionary<NSString *, id> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
     // check if user attributes contain our value as substring
     
     // check if condition value is invalid
@@ -140,7 +140,7 @@
     return [NSNumber numberWithBool:containsSubstring];
 }
 
-- (nullable NSNumber *)evaluateMatchTypeGreaterThan:(NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
+- (nullable NSNumber *)evaluateMatchTypeGreaterThan:(NSDictionary<NSString *, id> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
     // check if user attributes contain a value greater than our value
     
     // check if condition value is invalid
@@ -181,7 +181,7 @@
     return [NSNumber numberWithBool: ([userValue doubleValue] > [ourValue doubleValue])];
 }
 
-- (nullable NSNumber *)evaluateMatchTypeLessThan:(NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
+- (nullable NSNumber *)evaluateMatchTypeLessThan:(NSDictionary<NSString *, id> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
     // check if user attributes contain a value lesser than our value
     
     // check if condition value is invalid
@@ -222,7 +222,7 @@
     return [NSNumber numberWithBool: ([userValue doubleValue] < [ourValue doubleValue])];
 }
 
-- (nullable NSNumber *)evaluateCustomMatchType:(NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
+- (nullable NSNumber *)evaluateCustomMatchType:(NSDictionary<NSString *, id> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
     
     if (![self.type isEqual:OPTLYDatafileKeysCustomAttributeConditionType]){
         //Check if given type is the required type
@@ -268,7 +268,7 @@
 /**
  * Evaluates the condition against the user attributes, returns NULL if invalid.
  */
-- (nullable NSNumber *)evaluateConditionsWithAttributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
+- (nullable NSNumber *)evaluateConditionsWithAttributes:(nullable NSDictionary<NSString *, id> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
     // check user attribute value for the condition and match type against our condition value
     return [self evaluateCustomMatchType: attributes projectConfig:config];
 }

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYCondition.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYCondition.h
@@ -22,7 +22,7 @@
 /**
  * Evaluate the condition against the user attributes.
  */
-- (nullable NSNumber *)evaluateConditionsWithAttributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config;
+- (nullable NSNumber *)evaluateConditionsWithAttributes:(nullable NSDictionary<NSString *, id> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config;
 
 @end
 

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYCondition.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYCondition.m
@@ -183,7 +183,7 @@
 
 @implementation OPTLYAndCondition
 
-- (nullable NSNumber *)evaluateConditionsWithAttributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
+- (nullable NSNumber *)evaluateConditionsWithAttributes:(nullable NSDictionary<NSString *, id> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
     // According to the matrix:
     // false and true is false
     // false and null is false
@@ -218,7 +218,7 @@
 
 @implementation OPTLYOrCondition
 
-- (nullable NSNumber *)evaluateConditionsWithAttributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
+- (nullable NSNumber *)evaluateConditionsWithAttributes:(nullable NSDictionary<NSString *, id> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
     // According to the matrix:
     // true returns true
     // false or null is null
@@ -250,7 +250,7 @@
 
 @implementation OPTLYNotCondition
 
-- (nullable NSNumber *)evaluateConditionsWithAttributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
+- (nullable NSNumber *)evaluateConditionsWithAttributes:(nullable NSDictionary<NSString *, id> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
     // return the negative of the subcondition
     NSNumber * result = [NSNumber new];
     result = [self.subCondition evaluateConditionsWithAttributes:attributes projectConfig:config];

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYDecisionService.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYDecisionService.h
@@ -54,7 +54,7 @@
  */
 - (nullable OPTLYVariation *)getVariation:(nonnull NSString *)userId
                                experiment:(nonnull OPTLYExperiment *)experiment
-                               attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes;
+                               attributes:(nullable NSDictionary<NSString *, id> *)attributes;
 
 /**
  * Get a variation the user is bucketed into for the given FeatureFlag
@@ -65,6 +65,6 @@
  */
 - (nullable OPTLYFeatureDecision *)getVariationForFeature:(nonnull OPTLYFeatureFlag *)featureFlag
                                              userId:(nonnull NSString *)userId
-                                         attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes;
+                                         attributes:(nullable NSDictionary<NSString *, id> *)attributes;
 
 @end

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYDecisionService.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYDecisionService.m
@@ -53,7 +53,7 @@
 
 - (OPTLYVariation *)getVariation:(NSString *)userId
                       experiment:(OPTLYExperiment *)experiment
-                      attributes:(NSDictionary<NSString *, NSObject *> *)attributes
+                      attributes:(NSDictionary<NSString *, id> *)attributes
 {
     NSDictionary *userProfileDict = nil;
     OPTLYVariation *bucketedVariation = nil;
@@ -126,7 +126,7 @@
 
 - (OPTLYFeatureDecision *)getVariationForFeature:(OPTLYFeatureFlag *)featureFlag
                                           userId:(NSString *)userId
-                                      attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
+                                      attributes:(NSDictionary<NSString *, id> *)attributes {
     
     //Evaluate in this order:
     
@@ -158,7 +158,7 @@
 # pragma mark - Helper Methods
 
 - (NSString *)getBucketingId:(NSString *)userId
-                  attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
+                  attributes:(NSDictionary<NSString *, id> *)attributes {
     
     // By default, the bucketing ID should be the user ID .
     NSString *bucketingId = userId;
@@ -194,7 +194,7 @@
 - (OPTLYFeatureDecision *)getVariationForFeatureGroup:(OPTLYFeatureFlag *)featureFlag
                                               groupId:(NSString *)groupId
                                                userId:(NSString *)userId
-                                           attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
+                                           attributes:(NSDictionary<NSString *, id> *)attributes {
     
     OPTLYFeatureDecision *decision = nil;
     NSString *logMessage = nil;
@@ -230,7 +230,7 @@
 
 - (OPTLYFeatureDecision *)getVariationForFeatureExperiment:(OPTLYFeatureFlag *)featureFlag
                                                     userId:(NSString *)userId
-                                                attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
+                                                attributes:(NSDictionary<NSString *, id> *)attributes {
     
     NSString *featureFlagKey = featureFlag.key;
     NSArray *experimentIds = featureFlag.experimentIds;
@@ -266,7 +266,7 @@
 
 - (OPTLYFeatureDecision *)getVariationForFeatureRollout:(OPTLYFeatureFlag *)featureFlag
                                                  userId:(NSString *)userId
-                                             attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
+                                             attributes:(NSDictionary<NSString *, id> *)attributes {
     
     NSString *bucketing_id = [self getBucketingId:userId attributes:attributes];
     NSString *featureFlagKey = featureFlag.key;
@@ -451,7 +451,7 @@
 
 - (nullable NSNumber *)evaluateAudienceWithId:(NSString *)audienceId
                                        config:(OPTLYProjectConfig *)config
-                                   attributes:(NSDictionary<NSString *, NSObject *> *)attributes
+                                   attributes:(NSDictionary<NSString *, id> *)attributes
 {
     OPTLYAudience *audience = [config getAudienceForId:audienceId];
     return [audience evaluateConditionsWithAttributes:attributes projectConfig:config];
@@ -459,7 +459,7 @@
 
 - (BOOL)evaluateAudienceIdsForExperiment:(OPTLYExperiment *)experiment
                                   config:(OPTLYProjectConfig *)config
-                              attributes:(NSDictionary<NSString *, NSObject *> *)attributes
+                              attributes:(NSDictionary<NSString *, id> *)attributes
 {
     NSArray *audienceIds = experiment.audienceIds;
     // if there are no audiences, ALL users should be part of the experiment
@@ -478,7 +478,7 @@
 
 - (BOOL)evaluateAudienceConditionsForExperiment:(OPTLYExperiment *)experiment
                                          config:(OPTLYProjectConfig *)config
-                                     attributes:(NSDictionary<NSString *, NSObject *> *)attributes
+                                     attributes:(NSDictionary<NSString *, id> *)attributes
 {
     if (experiment.audienceConditions.count == 0) {
         return true;
@@ -505,7 +505,7 @@
 }
 
 // Returns empty dictionary if attributes nil
-- (NSDictionary<NSString *, NSObject *> *)validateAttributes:(NSDictionary<NSString *, NSObject *> *)attributes
+- (NSDictionary<NSString *, id> *)validateAttributes:(NSDictionary<NSString *, id> *)attributes
 {
     // if there are audiences, but no user attributes, Defaults to empty attributes
     if (attributes == nil) {
@@ -516,7 +516,7 @@
 
 - (BOOL)isUserInExperiment:(OPTLYProjectConfig *)config
                 experiment:(OPTLYExperiment *)experiment
-                attributes:(NSDictionary<NSString *, NSObject *> *)attributes
+                attributes:(NSDictionary<NSString *, id> *)attributes
 {
     attributes = [self validateAttributes:attributes];
     
@@ -531,7 +531,7 @@
 - (BOOL)userPassesTargeting:(OPTLYProjectConfig *)config
                  experiment:(OPTLYExperiment *)experiment
                      userId:(NSString *)userId
-                 attributes:(NSDictionary<NSString *, NSObject *> *)attributes
+                 attributes:(NSDictionary<NSString *, id> *)attributes
 {
     // check if the user is in the experiment
     BOOL isUserInExperiment = [self isUserInExperiment:config experiment:experiment attributes:attributes];

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_END
 - (nullable NSDictionary *)buildImpressionEventForUser:(nonnull NSString *)userId
                                             experiment:(nonnull OPTLYExperiment *)experiment
                                              variation:(nonnull OPTLYVariation *)variation
-                                            attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes;
+                                            attributes:(nullable NSDictionary<NSString *, id> *)attributes;
    
 /**
  * Create the parameters for a conversion event.
@@ -58,7 +58,7 @@ NS_ASSUME_NONNULL_END
 - (nullable NSDictionary *)buildConversionEventForUser:(nonnull NSString *)userId
                                                  event:(nonnull OPTLYEvent *)event
                                              eventTags:(nullable NSDictionary *)eventTags
-                                            attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes;
+                                            attributes:(nullable NSDictionary<NSString *, id> *)attributes;
 @end
 
 @interface OPTLYEventBuilderDefault : NSObject<OPTLYEventBuilder>

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYEventBuilder.m
@@ -56,7 +56,7 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
 - (NSDictionary *)buildImpressionEventForUser:(NSString *)userId
                                   experiment:(OPTLYExperiment *)experiment
                                    variation:(OPTLYVariation *)variation
-                                  attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
+                                  attributes:(NSDictionary<NSString *, id> *)attributes {
     if (!self.config) {
         return nil;
     }
@@ -71,7 +71,7 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
 - (NSDictionary *)buildConversionEventForUser:(NSString *)userId
                                        event:(OPTLYEvent *)event
                                    eventTags:(NSDictionary *)eventTags
-                                  attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
+                                  attributes:(NSDictionary<NSString *, id> *)attributes {
 
     if (!self.config) {
         return nil;
@@ -87,7 +87,7 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
 }
 
 - (NSDictionary *)createCommonParamsForUser:(NSString *)userId
-                                 attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
+                                 attributes:(NSDictionary<NSString *, id> *)attributes {
     NSMutableDictionary *commonParams = [NSMutableDictionary new];
     
     NSMutableDictionary *visitor = [NSMutableDictionary new];
@@ -199,7 +199,7 @@ NSString * const OPTLYEventBuilderEventsTicketURL   = @"https://logx.optimizely.
 }
 
 - (NSArray *)createUserFeatures:(OPTLYProjectConfig *)config
-                     attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
+                     attributes:(NSDictionary<NSString *, id> *)attributes {
     
     NSNumber *botFiltering = config.botFiltering;
     NSMutableArray *features = [NSMutableArray new];

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYExperiment.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYExperiment.m
@@ -62,7 +62,7 @@ NSString * const OPTLYExperimentStatusRunning = @"Running";
     }
 }
 
-- (nullable NSNumber *)evaluateConditionsWithAttributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
+- (nullable NSNumber *)evaluateConditionsWithAttributes:(nullable NSDictionary<NSString *, id> *)attributes projectConfig:(nullable OPTLYProjectConfig *)config {
 
     NSObject<OPTLYCondition> *condition = (NSObject<OPTLYCondition> *)[self.audienceConditions firstObject];
     if (condition) {

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYNotificationCenter.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYNotificationCenter.h
@@ -26,15 +26,15 @@ typedef NS_ENUM(NSUInteger, OPTLYNotificationType) {
 
 typedef void (^ActivateListener)(OPTLYExperiment * _Nonnull experiment,
                                  NSString * _Nonnull userId,
-                                 NSDictionary<NSString *, NSObject *> * _Nullable attributes,
+                                 NSDictionary<NSString *, id> * _Nullable attributes,
                                  OPTLYVariation * _Nonnull variation,
-                                 NSDictionary<NSString *,NSObject *> * _Nonnull event);
+                                 NSDictionary<NSString *,id> * _Nonnull event);
 
 typedef void (^TrackListener)(NSString * _Nonnull eventKey,
                               NSString * _Nonnull userId,
-                              NSDictionary<NSString *, NSObject *> * _Nullable attributes,
+                              NSDictionary<NSString *, id> * _Nullable attributes,
                               NSDictionary * _Nullable eventTags,
-                              NSDictionary<NSString *,NSObject *> * _Nonnull event);
+                              NSDictionary<NSString *,id> * _Nonnull event);
 
 typedef void (^GenericListener)(NSDictionary * _Nonnull args);
 

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYProjectConfig.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYProjectConfig.h
@@ -167,7 +167,7 @@ __attribute((deprecated("Use OPTLYProjectConfig initWithBuilder method instead."
  */
 - (nullable OPTLYVariation *)getVariationForExperiment:(nonnull NSString *)experimentKey
                                                 userId:(nonnull NSString *)userId
-                                            attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes
+                                            attributes:(nullable NSDictionary<NSString *, id> *)attributes
                                               bucketer:(nullable id<OPTLYBucketer>)bucketer;
 
 @end

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYProjectConfig.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYProjectConfig.m
@@ -590,7 +590,7 @@ static NSArray *supportedDatafileVersions = nil;
 // TODO: Remove bucketer from parameters -- this is not needed
 - (OPTLYVariation *)getVariationForExperiment:(NSString *)experimentKey
                                        userId:(NSString *)userId
-                                   attributes:(NSDictionary<NSString *, NSObject *> *)attributes
+                                   attributes:(NSDictionary<NSString *, id> *)attributes
                                      bucketer:(id<OPTLYBucketer>)bucketer
 {
     OPTLYExperiment *experiment = [self getExperimentForKey:experimentKey];

--- a/OptimizelySDKCore/OptimizelySDKCore/Optimizely.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/Optimizely.h
@@ -71,7 +71,7 @@ extern NSString * _Nonnull const OptimizelyNotificationsUserDictionaryExperiment
  */
 - (nullable OPTLYVariation *)activate:(nonnull NSString *)experimentKey
                                userId:(nonnull NSString *)userId
-                           attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes;
+                           attributes:(nullable NSDictionary<NSString *, id> *)attributes;
 
 #pragma mark - getVariation methods
 /**
@@ -117,7 +117,7 @@ extern NSString * _Nonnull const OptimizelyNotificationsUserDictionaryExperiment
  */
 - (nullable OPTLYVariation *)variation:(nonnull NSString *)experimentKey
                                 userId:(nonnull NSString *)userId
-                            attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes;
+                            attributes:(nullable NSDictionary<NSString *, id> *)attributes;
 
 #pragma mark - Forced Variation Methods
 /**
@@ -182,7 +182,7 @@ extern NSString * _Nonnull const OptimizelyNotificationsUserDictionaryExperiment
  *
  * @return           `YES` if the feature is enabled. `NO` if the feature is disabled or couldn't be found.
  */
-- (BOOL)isFeatureEnabled:(nullable NSString *)featureKey userId:(nullable NSString *)userId attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes;
+- (BOOL)isFeatureEnabled:(nullable NSString *)featureKey userId:(nullable NSString *)userId attributes:(nullable NSDictionary<NSString *, id> *)attributes;
 
 /**
  * Evaluates the specified boolean feature variable and returns its value.
@@ -203,7 +203,7 @@ extern NSString * _Nonnull const OptimizelyNotificationsUserDictionaryExperiment
 - (nullable NSNumber *)getFeatureVariableBoolean:(nullable NSString *)featureKey
                       variableKey:(nullable NSString *)variableKey
                            userId:(nullable NSString *)userId
-                       attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes;
+                       attributes:(nullable NSDictionary<NSString *, id> *)attributes;
 
 /**
  * Evaluates the specified double feature variable and returns its value.
@@ -224,7 +224,7 @@ extern NSString * _Nonnull const OptimizelyNotificationsUserDictionaryExperiment
 - (nullable NSNumber *)getFeatureVariableDouble:(nullable NSString *)featureKey
                        variableKey:(nullable NSString *)variableKey
                             userId:(nullable NSString *)userId
-                        attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes;
+                        attributes:(nullable NSDictionary<NSString *, id> *)attributes;
 
 /**
  * Evaluates the specified integer feature variable and returns its value.
@@ -245,7 +245,7 @@ extern NSString * _Nonnull const OptimizelyNotificationsUserDictionaryExperiment
 - (nullable NSNumber *)getFeatureVariableInteger:(nullable NSString *)featureKey
                      variableKey:(nullable NSString *)variableKey
                           userId:(nullable NSString *)userId
-                      attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes;
+                      attributes:(nullable NSDictionary<NSString *, id> *)attributes;
 
 /**
  * Evaluates the specified string feature variable and returns its value.
@@ -266,7 +266,7 @@ extern NSString * _Nonnull const OptimizelyNotificationsUserDictionaryExperiment
 - (nullable NSString *)getFeatureVariableString:(nullable NSString *)featureKey
                            variableKey:(nullable NSString *)variableKey
                                 userId:(nullable NSString *)userId
-                            attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes;
+                            attributes:(nullable NSDictionary<NSString *, id> *)attributes;
 
 /**
  * Retrieves a list of features that are enabled for the user.
@@ -284,7 +284,7 @@ extern NSString * _Nonnull const OptimizelyNotificationsUserDictionaryExperiment
  *                   features could be found for the specified user. 
  */
 - (NSArray<NSString *> *_Nonnull)getEnabledFeatures:(nullable NSString *)userId
-                                         attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes;
+                                         attributes:(nullable NSDictionary<NSString *, id> *)attributes;
 
 #pragma mark - trackEvent methods
 /**
@@ -321,7 +321,7 @@ extern NSString * _Nonnull const OptimizelyNotificationsUserDictionaryExperiment
  */
 - (void)track:(nonnull NSString *)eventKey
        userId:(nonnull NSString *)userId
-   attributes:(nonnull NSDictionary<NSString *, NSObject *> *)attributes;
+   attributes:(nonnull NSDictionary<NSString *, id> *)attributes;
 
 /**
  * Tracks a conversion event for a user whose attributes meet the default audience conditions for an experiment. 
@@ -360,7 +360,7 @@ extern NSString * _Nonnull const OptimizelyNotificationsUserDictionaryExperiment
  */
 - (void)track:(nonnull NSString *)eventKey
        userId:(nonnull NSString *)userId
-   attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes
+   attributes:(nullable NSDictionary<NSString *, id> *)attributes
     eventTags:(nullable NSDictionary<NSString *, id> *)eventTags;
 
 @end
@@ -414,7 +414,7 @@ __attribute((deprecated("Use Optimizely initWithBuilder method instead.")));
  */
 - (void)track:(nonnull NSString *)eventKey
        userId:(nonnull NSString *)userId
-   attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes
+   attributes:(nullable NSDictionary<NSString *, id> *)attributes
     eventTags:(nullable NSDictionary<NSString *, id> *)eventTags;
 
 @end

--- a/OptimizelySDKCore/OptimizelySDKCore/Optimizely.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/Optimizely.m
@@ -101,14 +101,14 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
 
 - (OPTLYVariation *)activate:(NSString *)experimentKey
                       userId:(NSString *)userId
-                  attributes:(NSDictionary<NSString *, NSObject *> *)attributes
+                  attributes:(NSDictionary<NSString *, id> *)attributes
 {
     return [self activate:experimentKey userId:userId attributes:attributes callback:nil];
 }
 
 - (OPTLYVariation *)activate:(NSString *)experimentKey
                       userId:(NSString *)userId
-                  attributes:(NSDictionary<NSString *, NSObject *> *)attributes
+                  attributes:(NSDictionary<NSString *, id> *)attributes
                     callback:(void (^)(NSError *))callback {
     
     __weak void (^_callback)(NSError *) = callback ? : ^(NSError *error) {};
@@ -179,7 +179,7 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
 
 - (OPTLYVariation *)variation:(NSString *)experimentKey
                        userId:(NSString *)userId
-                   attributes:(NSDictionary<NSString *, NSObject *> *)attributes
+                   attributes:(NSDictionary<NSString *, id> *)attributes
 {
     OPTLYVariation *bucketedVariation = [self.config getVariationForExperiment:experimentKey
                                                                         userId:userId
@@ -214,7 +214,7 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
 
 #pragma mark - Feature Flag Methods
 
-- (BOOL)isFeatureEnabled:(NSString *)featureKey userId:(NSString *)userId attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes {
+- (BOOL)isFeatureEnabled:(NSString *)featureKey userId:(NSString *)userId attributes:(nullable NSDictionary<NSString *, id> *)attributes {
     
     NSMutableDictionary<NSString *, NSString *> *inputValues = [[NSMutableDictionary alloc] initWithDictionary:@{
                                                                                                                     OptimizelyNotificationsUserDictionaryUserIdKey:[self ObjectOrNull:userId],
@@ -262,7 +262,7 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
                                   featureKey:(nullable NSString *)featureKey
                                  variableKey:(nullable NSString *)variableKey
                                       userId:(nullable NSString *)userId
-                                  attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes {
+                                  attributes:(nullable NSDictionary<NSString *, id> *)attributes {
     
     NSMutableDictionary<NSString *, NSString *> *inputValues = [[NSMutableDictionary alloc] initWithDictionary:@{
                                                                                                                     OptimizelyNotificationsUserDictionaryUserIdKey:[self ObjectOrNull:userId],
@@ -319,7 +319,7 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
 - (NSNumber *)getFeatureVariableBoolean:(nullable NSString *)featureKey
                       variableKey:(nullable NSString *)variableKey
                            userId:(nullable NSString *)userId
-                       attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes {
+                       attributes:(nullable NSDictionary<NSString *, id> *)attributes {
     
     NSString *variableValue = [self getFeatureVariableValueForType:FeatureVariableTypeBoolean
                                                         featureKey:featureKey
@@ -336,7 +336,7 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
 - (NSNumber *)getFeatureVariableDouble:(nullable NSString *)featureKey
                       variableKey:(nullable NSString *)variableKey
                            userId:(nullable NSString *)userId
-                       attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes {
+                       attributes:(nullable NSDictionary<NSString *, id> *)attributes {
     
     NSString *variableValue = [self getFeatureVariableValueForType:FeatureVariableTypeDouble
                                                         featureKey:featureKey
@@ -354,7 +354,7 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
 - (NSNumber *)getFeatureVariableInteger:(nullable NSString *)featureKey
                        variableKey:(nullable NSString *)variableKey
                             userId:(nullable NSString *)userId
-                        attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes {
+                        attributes:(nullable NSDictionary<NSString *, id> *)attributes {
     
     NSString *variableValue = [self getFeatureVariableValueForType:FeatureVariableTypeInteger
                                                         featureKey:featureKey
@@ -371,7 +371,7 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
 - (NSString *)getFeatureVariableString:(nullable NSString *)featureKey
                            variableKey:(nullable NSString *)variableKey
                                 userId:(nullable NSString *)userId
-                            attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes {
+                            attributes:(nullable NSDictionary<NSString *, id> *)attributes {
     return [self getFeatureVariableValueForType:FeatureVariableTypeString
                                      featureKey:featureKey
                                     variableKey:variableKey
@@ -380,7 +380,7 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
 }
     
 - (NSArray<NSString *> *)getEnabledFeatures:(NSString *)userId
-                                attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
+                                attributes:(NSDictionary<NSString *, id> *)attributes {
     
     
     NSMutableArray<NSString *> *enabledFeatures = [NSMutableArray new];
@@ -410,7 +410,7 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
 
 - (void)track:(NSString *)eventKey
        userId:(NSString *)userId
-   attributes:(NSDictionary<NSString *, NSObject *> * )attributes {
+   attributes:(NSDictionary<NSString *, id> * )attributes {
     [self track:eventKey userId:userId attributes:attributes eventTags:nil];
 }
 
@@ -422,7 +422,7 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
 
 - (void)track:(NSString *)eventKey
        userId:(NSString *)userId
-   attributes:(NSDictionary<NSString *, NSObject *> *)attributes
+   attributes:(NSDictionary<NSString *, id> *)attributes
     eventTags:(NSDictionary<NSString *,id> *)eventTags {
     
     if ([eventKey getValidString] == nil) {
@@ -509,7 +509,7 @@ NSString *const OptimizelyNotificationsUserDictionaryExperimentVariationMappingK
 - (OPTLYVariation *)sendImpressionEventFor:(OPTLYExperiment *)experiment
                                  variation:(OPTLYVariation *)variation
                                     userId:(NSString *)userId
-                                attributes:(NSDictionary<NSString *, NSObject *> *)attributes
+                                attributes:(NSDictionary<NSString *, id> *)attributes
                                   callback:(void (^)(NSError *))callback {
     
     // send impression event

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYConditionTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYConditionTest.m
@@ -30,7 +30,7 @@
 
 @interface OPTLYConditionTest : XCTestCase
 
-@property NSDictionary<NSString *, NSObject *> *testUserAttributes;
+@property NSDictionary<NSString *, id> *testUserAttributes;
 @property (nonatomic, strong) NSData *typedAudienceDatafile;
 @property (nonatomic, strong) Optimizely *optimizelyTypedAudience;
 
@@ -165,7 +165,7 @@
 
 - (void)testNotConditionReturnsFalseWhenComplexAudienceConditionReturnsTrue {
     id loggerMock = OCMPartialMock((OPTLYLoggerDefault *)self.optimizelyTypedAudience.logger);
-    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+    NSDictionary<NSString *, id> *userAttributes = @{
                                                              @"house": @"Gryffindor"
                                                              };
     NSArray *notConditionArray = @[@"not", @"3468206642"];
@@ -182,7 +182,7 @@
 }
 
 - (void)testNotConditionReturnsTrueWhenComplexAudienceConditionsReturnsFalse {
-    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+    NSDictionary<NSString *, id> *userAttributes = @{
                                                              @"house": @"Gryffindor"
                                                              };
     NSArray *notConditionArray = @[@"not", @"3988293898"];
@@ -193,7 +193,7 @@
 }
 
 - (void)testNotConditionReturnsNilWithComplexAudienceConditionWhenEmptyOrNullAttributes {
-    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+    NSDictionary<NSString *, id> *userAttributes = @{
                                                              @"house": [NSNull null]
                                                              };
     NSArray *notConditionArray = @[@"not", @"3988293898"];
@@ -323,7 +323,7 @@
 
 - (void)testOrConditionReturnsTrueWhenAnyComplexAudienceConditionReturnsTrue {
     id loggerMock = OCMPartialMock((OPTLYLoggerDefault *)self.optimizelyTypedAudience.logger);
-    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+    NSDictionary<NSString *, id> *userAttributes = @{
                                                              @"house": @"Gryffindor"
                                                              };
     NSArray *orConditionArray = @[@"or", @"3468206642",@"2"];
@@ -341,7 +341,7 @@
 }
 
 - (void)testOrConditionReturnsFalseWhenAllComplexAudienceConditionsReturnsFalse {
-    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+    NSDictionary<NSString *, id> *userAttributes = @{
                                                              @"house": @"Gryffindor"
                                                              };
     NSArray *orConditionArray = @[@"or", @"1",@"2"];
@@ -454,7 +454,7 @@
 
 - (void)testAndConditionReturnsFalseWhenAnyComplexAudienceConditionReturnsFalse {
     id loggerMock = OCMPartialMock((OPTLYLoggerDefault *)self.optimizelyTypedAudience.logger);
-    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+    NSDictionary<NSString *, id> *userAttributes = @{
                                                              @"house": @"Gryffindor"
                                                              };
     NSArray *andConditionArray = @[@"and", @"3468206642",@"2"];
@@ -471,7 +471,7 @@
 }
 
 - (void)testAndConditionReturnsTrueWhenAllComplexAudienceConditionsReturnsTrue {
-    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+    NSDictionary<NSString *, id> *userAttributes = @{
                                                              @"house": @"Gryffindor"
                                                              };
     NSArray *andConditionArray = @[@"and", @"3468206642"];

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYDecisionServiceTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYDecisionServiceTest.m
@@ -143,7 +143,7 @@ static NSString * const kFeatureFlagNoBucketedRuleRolloutKey = @"booleanSingleVa
 
 - (nullable NSNumber *)evaluateAudienceWithId:(NSString *)audienceId
                                        config:(OPTLYProjectConfig *)config
-                                   attributes:(NSDictionary<NSString *, NSObject *> *)attributes;
+                                   attributes:(NSDictionary<NSString *, id> *)attributes;
 @end
 
 @implementation OPTLYDecisionServiceTest

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYEventBuilderTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYEventBuilderTest.m
@@ -92,7 +92,7 @@ typedef enum : NSUInteger {
 @interface Optimizely(test)
 - (NSArray<NSDictionary *> *)decisionsFor:(OPTLYEvent *)event
                                    userId:(NSString *)userId
-                               attributes:(NSDictionary<NSString *,NSString *> *)attributes;
+                               attributes:(NSDictionary<NSString *,id> *)attributes;
 @end
 
 @interface OPTLYEventBuilderDefault(Tests)

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYNotificationCenterTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYNotificationCenterTest.m
@@ -69,7 +69,7 @@ static NSString *const kAttributeKeyObject = @"dummy_object";
         [weakSelf.projectConfig.logger logMessage:[NSString stringWithFormat:logMessage, userId] withLevel:OptimizelyLogLevelInfo];
         [weakSelf.projectConfig.logger logMessage:[NSString stringWithFormat:logMessage, variation.variationKey] withLevel:OptimizelyLogLevelInfo];
     };
-    weakSelf.anotherActivateNotification = ^(OPTLYExperiment *experiment, NSString *userId, NSDictionary<NSString *, id> *attributes, OPTLYVariation *variation, NSDictionary<NSString *,NSString> *event) {
+    weakSelf.anotherActivateNotification = ^(OPTLYExperiment *experiment, NSString *userId, NSDictionary<NSString *, id> *attributes, OPTLYVariation *variation, NSDictionary<NSString *,NSString *> *event) {
         NSString *logMessage = @"activate notification called with %@";
         [weakSelf.projectConfig.logger logMessage:[NSString stringWithFormat:logMessage, experiment.experimentKey] withLevel:OptimizelyLogLevelInfo];
         [weakSelf.projectConfig.logger logMessage:[NSString stringWithFormat:logMessage, userId] withLevel:OptimizelyLogLevelInfo];

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYNotificationCenterTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYNotificationCenterTest.m
@@ -63,19 +63,19 @@ static NSString *const kAttributeKeyObject = @"dummy_object";
     }]];
     self.notificationCenter = [[OPTLYNotificationCenter alloc] initWithProjectConfig:self.projectConfig];
     __weak typeof(self) weakSelf = self;
-    weakSelf.activateNotification = ^(OPTLYExperiment *experiment, NSString *userId, NSDictionary<NSString *, NSObject *> *attributes, OPTLYVariation *variation, NSDictionary<NSString *,NSString *> *event) {
+    weakSelf.activateNotification = ^(OPTLYExperiment *experiment, NSString *userId, NSDictionary<NSString *, id> *attributes, OPTLYVariation *variation, NSDictionary<NSString *,NSString *> *event) {
         NSString *logMessage = @"activate notification called with %@";
         [weakSelf.projectConfig.logger logMessage:[NSString stringWithFormat:logMessage, experiment.experimentKey] withLevel:OptimizelyLogLevelInfo];
         [weakSelf.projectConfig.logger logMessage:[NSString stringWithFormat:logMessage, userId] withLevel:OptimizelyLogLevelInfo];
         [weakSelf.projectConfig.logger logMessage:[NSString stringWithFormat:logMessage, variation.variationKey] withLevel:OptimizelyLogLevelInfo];
     };
-    weakSelf.anotherActivateNotification = ^(OPTLYExperiment *experiment, NSString *userId, NSDictionary<NSString *, NSObject *> *attributes, OPTLYVariation *variation, NSDictionary<NSString *,NSString *> *event) {
+    weakSelf.anotherActivateNotification = ^(OPTLYExperiment *experiment, NSString *userId, NSDictionary<NSString *, id> *attributes, OPTLYVariation *variation, NSDictionary<NSString *,NSString> *event) {
         NSString *logMessage = @"activate notification called with %@";
         [weakSelf.projectConfig.logger logMessage:[NSString stringWithFormat:logMessage, experiment.experimentKey] withLevel:OptimizelyLogLevelInfo];
         [weakSelf.projectConfig.logger logMessage:[NSString stringWithFormat:logMessage, userId] withLevel:OptimizelyLogLevelInfo];
         [weakSelf.projectConfig.logger logMessage:[NSString stringWithFormat:logMessage, variation.variationKey] withLevel:OptimizelyLogLevelInfo];
     };
-    weakSelf.trackNotification = ^(NSString *eventKey, NSString *userId, NSDictionary<NSString *, NSObject *> *attributes, NSDictionary *eventTags, NSDictionary<NSString *,NSString *> *event) {
+    weakSelf.trackNotification = ^(NSString *eventKey, NSString *userId, NSDictionary<NSString *, id> *attributes, NSDictionary *eventTags, NSDictionary<NSString *,NSString *> *event) {
         NSString *logMessage = @"track notification called with %@";
         [weakSelf.projectConfig.logger logMessage:[NSString stringWithFormat:logMessage, eventKey] withLevel:OptimizelyLogLevelInfo];
         [weakSelf.projectConfig.logger logMessage:[NSString stringWithFormat:logMessage, userId] withLevel:OptimizelyLogLevelInfo];

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYNotificationCenterTest2.swift
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYNotificationCenterTest2.swift
@@ -53,7 +53,22 @@ class OPTLYNotificationCenterTest2: XCTestCase {
         optimizely?.activate("whiteListExperiment", userId: self.userId)
         XCTAssertEqual(experiment!.experimentKey, experimentKey!)
     }
-    
+
+    func testActivateWithAttributesExample() {
+        var experimentKey:String?
+        var version:Double?
+        let experiment = optimizely?.config?.getExperimentForKey("whiteListExperiment")
+        XCTAssertNotNil(experiment, "Experiment should not be nil to activate")
+        
+        optimizely?.notificationCenter?.addActivateNotificationListener({ (experiment, userId, attributes, variation, logEvent) in
+            experimentKey = experiment.experimentKey
+            version = attributes?["browser_version"] as? Double
+        })
+        optimizely?.activate("whiteListExperiment", userId: self.userId, attributes:["browser_version": 68.1])
+        XCTAssertEqual(experiment!.experimentKey, experimentKey!)
+        XCTAssertEqual(version, 68.1)
+    }
+
     func testTrackExample() {
         var notificationEventKey:String?
         let event = optimizely?.config?.getEventForKey("testEvent")

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelySwiftTest.swift
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelySwiftTest.swift
@@ -17,22 +17,105 @@
 import XCTest
 import OptimizelySDKCore
 
+let kAttributeKeyBrowserType = "browser_type"
+let kAttributeKeyBrowserVersion = "browser_version"
+let kAttributeKeyBrowserBuildNumber = "browser_build_number"
+let kAttributeKeyBrowserIsDefault = "browser_is_default"
+let kUserId = "userId"
+
+
 class OptimizelySwiftTest: XCTestCase {
     
     var datafile: Data?
+    var typedAudienceDatafile:Data?
     var optimizely:Optimizely?
+    var optimizelyTypedAudience:Optimizely?
+    var attributes:[String:Any]?
+    
 
     override func setUp() {
         super.setUp()
         self.datafile = OPTLYTestHelper.loadJSONDatafile(intoDataObject: "test_data_10_experiments")
+        self.typedAudienceDatafile = OPTLYTestHelper.loadJSONDatafile(intoDataObject:"typed_audience_datafile")
+        
+        XCTAssertNotNil(self.datafile, "Data file should not be nil.")
+        self.optimizely = Optimizely.init(builder: OPTLYBuilder.init(block: { (builder) in
+            builder?.datafile = self.datafile
+            builder?.logger = OPTLYLoggerDefault.init(logLevel: OptimizelyLogLevel.off)
+            builder?.errorHandler = OPTLYErrorHandlerNoOp.init()
+        }))
+        
+        XCTAssertNotNil(self.typedAudienceDatafile, "Data file should not be nil.")
+        self.optimizelyTypedAudience = Optimizely.init(builder: OPTLYBuilder.init(block: { (builder) in
+            builder?.datafile = self.typedAudienceDatafile
+            builder?.logger = OPTLYLoggerDefault.init(logLevel: OptimizelyLogLevel.off)
+            builder?.errorHandler = OPTLYErrorHandlerNoOp.init()
+        }))
+        XCTAssertNotNil(self.optimizely, "Optimizely should not be nil");
+        XCTAssertNotNil(self.optimizelyTypedAudience, " Typed Optimizely should not be nil");
+        
+        self.attributes = [
+            kAttributeKeyBrowserType : "firefox",
+            kAttributeKeyBrowserVersion : 68.1,
+            kAttributeKeyBrowserBuildNumber : 106,
+            kAttributeKeyBrowserIsDefault : true]
+
     }
 
     override func tearDown() {
         super.tearDown()
         self.datafile = nil
         self.optimizely = nil
+        self.typedAudienceDatafile = nil
     }
     
+    func testVariationWithAudience() {
+    let experimentKey = "testExperimentWithFirefoxAudience";
+        let experiment = self.optimizely?.config?.getExperimentForKey(experimentKey)
+    XCTAssertNotNil(experiment);
+        var variation:OPTLYVariation?
+        
+    let attributesWithUserNotInAudience = ["browser_type" : "chrome"]
+    let attributesWithUserInAudience = ["browser_type" : "firefox"]
+    
+    // test get experiment without attributes
+        variation = self.optimizely?.variation(experimentKey, userId:kUserId)
+    XCTAssertNil(variation);
+    // test get experiment with bad attributes
+        variation = self.optimizely?.variation(experimentKey,
+    userId:kUserId,
+    attributes:attributesWithUserNotInAudience)
+    XCTAssertNil(variation);
+    // test get experiment with good attributes
+        variation = self.optimizely?.variation(experimentKey,
+    userId:kUserId,
+    attributes:attributesWithUserInAudience)
+    XCTAssertNotNil(variation);
+    }
+    
+    func testVariationWithAudienceTypeInteger() {
+    let experimentKey = "testExperimentWithFirefoxAudience"
+        let experiment = self.optimizely?.config?.getExperimentForKey(experimentKey)
+    XCTAssertNotNil(experiment)
+        var variation:OPTLYVariation?
+    let attributesWithUserNotInAudience = [kAttributeKeyBrowserBuildNumber : 601]
+    let attributesWithUserInAudience = [kAttributeKeyBrowserBuildNumber : 106]
+
+    // test get experiment without attributes
+    variation = self.optimizely?.variation(experimentKey, userId:kUserId)
+    XCTAssertNil(variation);
+    // test get experiment with bad attributes
+    variation = self.optimizely?.variation(experimentKey,
+    userId:kUserId,
+    attributes:attributesWithUserNotInAudience)
+    XCTAssertNil(variation);
+    // test get experiment with good attributes
+    variation = self.optimizely?.variation(experimentKey,
+    userId:kUserId,
+    attributes:attributesWithUserInAudience)
+    XCTAssertNotNil(variation);
+    }
+
     func testOptimizelyInitWithBuilder() {
         XCTAssertNotNil(self.datafile, "Data file should not be nil.")
         self.optimizely = Optimizely.init(builder: OPTLYBuilder.init(block: { (builder) in

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
@@ -72,11 +72,11 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 @end
 
 @implementation OPTLYNotificationTest
-- (void)onActivate:(OPTLYExperiment *)experiment userId:(NSString *)userId attributes:(NSDictionary<NSString *, NSObject *> *)attributes variation:(OPTLYVariation *)variation event:(NSDictionary<NSString *,NSString *> *)event {
+- (void)onActivate:(OPTLYExperiment *)experiment userId:(NSString *)userId attributes:(NSDictionary<NSString *,id> *)attributes variation:(OPTLYVariation *)variation event:(NSDictionary<NSString *,NSString *> *)event {
     
 }
 
-- (void)onTrack:(NSString *)eventKey userId:(NSString *)userId attributes:(NSDictionary<NSString *, NSObject *> *)attributes eventTags:(NSDictionary *)eventTags event:(NSDictionary<NSString *,NSString *> *)event {
+- (void)onTrack:(NSString *)eventKey userId:(NSString *)userId attributes:(NSDictionary<NSString *, id> *)attributes eventTags:(NSDictionary *)eventTags event:(NSDictionary<NSString *,NSString *> *)event {
     
 }
 @end
@@ -84,18 +84,18 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 @interface Optimizely(test)
 - (OPTLYVariation *)activate:(NSString *)experimentKey
                       userId:(NSString *)userId
-                  attributes:(NSDictionary<NSString *, NSObject *> *)attributes
+                  attributes:(NSDictionary<NSString *, id> *)attributes
                     callback:(void (^)(NSError *))callback;
 - (OPTLYVariation *)sendImpressionEventFor:(OPTLYExperiment *)experiment
                                  variation:(OPTLYVariation *)variation
                                     userId:(NSString *)userId
-                                attributes:(NSDictionary<NSString *, NSObject *> *)attributes
+                                attributes:(NSDictionary<NSString *, id> *)attributes
                                   callback:(void (^)(NSError *))callback;
 - (NSString *)getFeatureVariableValueForType:(NSString *)variableType
                                   featureKey:(nullable NSString *)featureKey
                                  variableKey:(nullable NSString *)variableKey
                                       userId:(nullable NSString *)userId
-                                  attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes;
+                                  attributes:(nullable NSDictionary<NSString *, id> *)attributes;
 @end
 
 @interface OPTLYEventBuilderDefault(Tests)
@@ -347,7 +347,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     OPTLYExperiment *experiment = [self.optimizely.config getExperimentForKey:kExperimentKeyForWhitelisting];
     __block NSString *notificationExperimentKey = nil;
     
-    [self.optimizely.notificationCenter addActivateNotificationListener:^(OPTLYExperiment *experiment, NSString *userId, NSDictionary<NSString *, NSObject *> *attributes, OPTLYVariation *variation, NSDictionary<NSString *,NSString *> *event) {
+    [self.optimizely.notificationCenter addActivateNotificationListener:^(OPTLYExperiment *experiment, NSString *userId, NSDictionary<NSString *, id> *attributes, OPTLYVariation *variation, NSDictionary<NSString *,NSString *> *event) {
         notificationExperimentKey = experiment.experimentId;
     }];
     
@@ -362,14 +362,14 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     OPTLYExperiment *experiment = [self.optimizely.config getExperimentForKey:kExperimentKeyForWhitelisting];
     __block NSString *notificationExperimentKey = nil;
     
-    NSDictionary<NSString *, NSObject *> *expectedAttributes = @{
+    NSDictionary<NSString *, id> *expectedAttributes = @{
                                                                  @"browser_name": @"chrome",
                                                                  @"buildno": @(10),
                                                                  @"buildversion": @(0.13)
                                                                  };
-    __block NSDictionary<NSString *, NSObject *> *actualAttributes;
+    __block NSDictionary<NSString *, id> *actualAttributes;
     
-    [self.optimizely.notificationCenter addActivateNotificationListener:^(OPTLYExperiment *experiment, NSString *userId, NSDictionary<NSString *, NSObject *> *attributes, OPTLYVariation *variation, NSDictionary<NSString *,NSString *> *event) {
+    [self.optimizely.notificationCenter addActivateNotificationListener:^(OPTLYExperiment *experiment, NSString *userId, NSDictionary<NSString *, id> *attributes, OPTLYVariation *variation, NSDictionary<NSString *,NSString *> *event) {
         notificationExperimentKey = experiment.experimentId;
         actualAttributes = attributes;
     }];
@@ -385,9 +385,9 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     
     OPTLYExperiment *experiment = [self.optimizely.config getExperimentForKey:kExperimentKeyForWhitelisting];
     __block NSString *notificationExperimentKey = nil;
-    __block NSDictionary<NSString *, NSObject *> *actualAttributes;
+    __block NSDictionary<NSString *, id> *actualAttributes;
     
-    [self.optimizely.notificationCenter addActivateNotificationListener:^(OPTLYExperiment *experiment, NSString *userId, NSDictionary<NSString *, NSObject *> *attributes, OPTLYVariation *variation, NSDictionary<NSString *,NSString *> *event) {
+    [self.optimizely.notificationCenter addActivateNotificationListener:^(OPTLYExperiment *experiment, NSString *userId, NSDictionary<NSString *, id> *attributes, OPTLYVariation *variation, NSDictionary<NSString *,NSString *> *event) {
         notificationExperimentKey = experiment.experimentId;
         actualAttributes = attributes;
     }];
@@ -436,10 +436,10 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     NSString *eventKey = @"testEvent";
     __block NSString *_userId = nil;
     __block NSString *notificationEventKey = nil;
-    __block NSDictionary<NSString *, NSObject *> *actualAttributes;
-    __block NSDictionary<NSString *, NSObject *> *actualEventTags;
+    __block NSDictionary<NSString *, id> *actualAttributes;
+    __block NSDictionary<NSString *, id> *actualEventTags;
     
-    [self.optimizely.notificationCenter addTrackNotificationListener:^(NSString * _Nonnull eventKey, NSString * _Nonnull userId, NSDictionary<NSString *, NSObject *> * _Nonnull attributes, NSDictionary * _Nonnull eventTags, NSDictionary<NSString *,NSObject *> * _Nonnull event) {
+    [self.optimizely.notificationCenter addTrackNotificationListener:^(NSString * _Nonnull eventKey, NSString * _Nonnull userId, NSDictionary<NSString *, id> * _Nonnull attributes, NSDictionary * _Nonnull eventTags, NSDictionary<NSString *,NSString *> * _Nonnull event) {
         _userId = userId;
         notificationEventKey = eventKey;
         actualAttributes = attributes;
@@ -489,7 +489,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     NSString *eventKey = @"testEvent";
     __block NSString *notificationEventKey = nil;
     
-    [self.optimizely.notificationCenter addTrackNotificationListener:^(NSString * _Nonnull eventKey, NSString * _Nonnull userId, NSDictionary<NSString *, NSObject *> * _Nonnull attributes, NSDictionary * _Nonnull eventTags, NSDictionary<NSString *,NSObject *> * _Nonnull event) {
+    [self.optimizely.notificationCenter addTrackNotificationListener:^(NSString * _Nonnull eventKey, NSString * _Nonnull userId, NSDictionary<NSString *, id> * _Nonnull attributes, NSDictionary * _Nonnull eventTags, NSDictionary<NSString *,NSObject *> * _Nonnull event) {
         notificationEventKey = eventKey;
     }];
     
@@ -501,17 +501,17 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     
     NSString *eventKey = @"testEvent";
     __block NSString *notificationEventKey = nil;
-    __block NSDictionary<NSString *, NSObject *> *actualAttributes;
-    __block NSDictionary<NSString *, NSObject *> *actualEventTags;
+    __block NSDictionary<NSString *, id> *actualAttributes;
+    __block NSDictionary<NSString *, id> *actualEventTags;
     
-    NSDictionary<NSString *, NSObject *> *expectedEventTags = @{
+    NSDictionary<NSString *, id> *expectedEventTags = @{
                                                                 OPTLYEventMetricNameRevenue: OPTLYEventMetricNameValue,
                                                                 @"event_int": @(11),
                                                                 @"event_version": @(1.3),
                                                                 @"event_bool": @(YES)
                                                                 };
     
-    [self.optimizely.notificationCenter addTrackNotificationListener:^(NSString * _Nonnull eventKey, NSString * _Nonnull userId, NSDictionary<NSString *, NSObject *> * _Nonnull attributes, NSDictionary * _Nonnull eventTags, NSDictionary<NSString *,NSObject *> * _Nonnull event) {
+    [self.optimizely.notificationCenter addTrackNotificationListener:^(NSString * _Nonnull eventKey, NSString * _Nonnull userId, NSDictionary<NSString *, id> * _Nonnull attributes, NSDictionary * _Nonnull eventTags, NSDictionary<NSString *,NSObject *> * _Nonnull event) {
         actualAttributes = attributes;
         actualEventTags = eventTags;
         notificationEventKey = eventKey;
@@ -527,10 +527,10 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     
     NSString *eventKey = @"testEvent";
     __block NSString *notificationEventKey = nil;
-    __block NSDictionary<NSString *, NSObject *> *actualAttributes;
-    __block NSDictionary<NSString *, NSObject *> *actualEventTags;
+    __block NSDictionary<NSString *, id> *actualAttributes;
+    __block NSDictionary<NSString *, id> *actualEventTags;
     
-    [self.optimizely.notificationCenter addTrackNotificationListener:^(NSString * _Nonnull eventKey, NSString * _Nonnull userId, NSDictionary<NSString *, NSObject *> * _Nonnull attributes, NSDictionary * _Nonnull eventTags, NSDictionary<NSString *,NSObject *> * _Nonnull event) {
+    [self.optimizely.notificationCenter addTrackNotificationListener:^(NSString * _Nonnull eventKey, NSString * _Nonnull userId, NSDictionary<NSString *, id> * _Nonnull attributes, NSDictionary * _Nonnull eventTags, NSDictionary<NSString *,NSObject *> * _Nonnull event) {
         actualAttributes = attributes;
         actualEventTags = eventTags;
         notificationEventKey = eventKey;
@@ -550,7 +550,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     __block NSString *notificationEventKey = nil;
     __block NSDictionary *notificationEventTags = nil;
     
-    [self.optimizely.notificationCenter addTrackNotificationListener:^(NSString * _Nonnull eventKey, NSString * _Nonnull userId, NSDictionary<NSString *, NSObject *> * _Nonnull attributes, NSDictionary * _Nonnull eventTags, NSDictionary<NSString *,NSObject *> * _Nonnull event) {
+    [self.optimizely.notificationCenter addTrackNotificationListener:^(NSString * _Nonnull eventKey, NSString * _Nonnull userId, NSDictionary<NSString *, id> * _Nonnull attributes, NSDictionary * _Nonnull eventTags, NSDictionary<NSString *,NSObject *> * _Nonnull event) {
         notificationEventKey = eventKey;
         notificationEventTags = eventTags;
     }];
@@ -1239,7 +1239,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 
 - (void)testActivateWithTypedAudiencesWithExactMatchType {
     // Should be included via exact match string audience with id '3468206642'
-    NSDictionary<NSString *, NSObject *> *expectedAttributes = @{
+    NSDictionary<NSString *, id> *expectedAttributes = @{
                                                                  @"house": @"Gryffindor"
                                                                  };
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"getActivatedVariation"];
@@ -1280,7 +1280,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 
 - (void)testActivateWithTypedAudiencesWithSubstringMatchType {
     // Should be included via substring match string audience with id '3988293898'
-    NSDictionary<NSString *, NSObject *> *expectedAttributes = @{
+    NSDictionary<NSString *, id> *expectedAttributes = @{
                                                                  @"house": @"222Slytherin"
                                                                  };
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"getActivatedVariation"];
@@ -1295,7 +1295,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 
 - (void)testActivateWithTypedAudiencesWithExistsMatchType {
     // Should be included via exists match string audience with id '3988293899'
-    NSDictionary<NSString *, NSObject *> *expectedAttributes = @{
+    NSDictionary<NSString *, id> *expectedAttributes = @{
                                                                  @"favorite_ice_cream": @1
                                                                  };
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"getActivatedVariation"];
@@ -1310,7 +1310,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 
 - (void)testActivateWithTypedAudiencesWithLtMatchType {
     // Should be included via lt match number audience with id '3468206644'
-    NSDictionary<NSString *, NSObject *> *expectedAttributes = @{
+    NSDictionary<NSString *, id> *expectedAttributes = @{
                                                                  @"lasers": @0.8
                                                                  };
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"getActivatedVariation"];
@@ -1325,7 +1325,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 
 - (void)testActivateWithTypedAudiencesWithGtMatchType {
     // Should be included via gt match number audience with id '3468206647'
-    NSDictionary<NSString *, NSObject *> *expectedAttributes = @{
+    NSDictionary<NSString *, id> *expectedAttributes = @{
                                                                  @"lasers": @71
                                                                  };
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"getActivatedVariation"];
@@ -1339,7 +1339,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 }
 
 - (void)testActivateExcludesUserFromExperimentWithTypedAudiences {
-    NSDictionary<NSString *, NSObject *> *expectedAttributes = @{
+    NSDictionary<NSString *, id> *expectedAttributes = @{
                                                                  @"house": @"Hufflepuff"
                                                                  };
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"getActivatedVariation"];
@@ -1355,7 +1355,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 - (void)testTrackWithTypedAudiences {
     NSString *eventId = @"item_bought";
     NSString *userId = @"user1";
-    NSDictionary<NSString *, NSObject *> *attributes = @{
+    NSDictionary<NSString *, id> *attributes = @{
                                                          @"house": @"Welcome to Slytherin!"
                                                          };
     id loggerMock = OCMPartialMock((OPTLYLoggerDefault *)self.optimizely.logger);
@@ -1374,7 +1374,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 - (void)testTrackExcludesUserFromExperimentWithTypedAudiences {
     NSString *eventId = @"item_bought";
     NSString *userId = @"user1";
-    NSDictionary<NSString *, NSObject *> *attributes = @{
+    NSDictionary<NSString *, id> *attributes = @{
                                                          @"house": @"Hufflepuff"
                                                          };
     id loggerMock = OCMPartialMock((OPTLYLoggerDefault *)self.optimizely.logger);
@@ -1391,7 +1391,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 - (void)testIsFeatureEnabledWithTypedAudiences {
     NSString *featureFlagKey = @"feat";
     NSString *userId = @"user1";
-    NSDictionary<NSString *, NSObject *> *attributes = @{
+    NSDictionary<NSString *, id> *attributes = @{
                                                          @"favorite_ice_cream": @"chocolate"
                                                          };
     XCTAssertTrue([self.optimizelyTypedAudience isFeatureEnabled:featureFlagKey userId:userId attributes:attributes]);
@@ -1405,7 +1405,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 - (void)testIsFeatureEnabledExcludesUserFromExperimentWithTypedAudiences {
     NSString *featureFlagKey = @"feat";
     NSString *userId = @"user1";
-    NSDictionary<NSString *, NSObject *> *attributes = @{
+    NSDictionary<NSString *, id> *attributes = @{
                                                          };
     XCTAssertFalse([self.optimizelyTypedAudience isFeatureEnabled:featureFlagKey userId:userId attributes:attributes]);
 }
@@ -1414,7 +1414,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     NSString *featureKey = @"feat_with_var";
     NSString *variableKey = @"x";
     NSString *userId = @"user1";
-    NSDictionary<NSString *, NSObject *> *attributes = @{
+    NSDictionary<NSString *, id> *attributes = @{
                                                          @"lasers": @71
                                                          };
     NSString *featureVariable = [self.optimizelyTypedAudience getFeatureVariableValueForType:FeatureVariableTypeString featureKey:featureKey variableKey:variableKey userId:userId attributes:attributes];
@@ -1431,7 +1431,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     NSString *featureKey = @"feat_with_var";
     NSString *variableKey = @"x";
     NSString *userId = @"user1";
-    NSDictionary<NSString *, NSObject *> *attributes = @{
+    NSDictionary<NSString *, id> *attributes = @{
                                                          @"lasers": @50
                                                          };
     NSString *featureVariable = [self.optimizelyTypedAudience getFeatureVariableValueForType:FeatureVariableTypeString featureKey:featureKey variableKey:variableKey userId:userId attributes:attributes];
@@ -1451,7 +1451,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
         builder.errorHandler = [OPTLYErrorHandlerNoOp new];
     }]];
     
-    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+    NSDictionary<NSString *, id> *userAttributes = @{
                                                              @"s_foo": @"foo",
                                                              @"b_true": @"N/A",
                                                              @"i_42": @43,
@@ -1482,7 +1482,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
         builder.errorHandler = [OPTLYErrorHandlerNoOp new];
     }]];
     
-    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+    NSDictionary<NSString *, id> *userAttributes = @{
                                                              @"s_foo": [NSNull null],
                                                              @"b_true": @"N/A",
                                                              @"i_42": @"N/A",
@@ -1507,18 +1507,18 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 
 - (void)testActivateWithAttributesComplexAudienceMatch {
     
-    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+    NSDictionary<NSString *, id> *userAttributes = @{
                                                              @"house": @"Welcome to Slytherin!",
                                                              @"lasers": @45.5
                                                              };
-    NSDictionary<NSString *, NSObject *> *expectedAttributes1 = @{
+    NSDictionary<NSString *, id> *expectedAttributes1 = @{
                                                                   @"shouldIndex": @1,
                                                                   @"type": @"custom",
                                                                   @"value": @45.5,
                                                                   @"entity_id": @"594016",
                                                                   @"key": @"lasers"
                                                                   };
-    NSDictionary<NSString *, NSObject *> *expectedAttributes2 = @{
+    NSDictionary<NSString *, id> *expectedAttributes2 = @{
                                                                   @"shouldIndex": @1,
                                                                   @"type": @"custom",
                                                                   @"value": @"Welcome to Slytherin!",
@@ -1529,7 +1529,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     __weak XCTestExpectation *expectation = [self expectationWithDescription:@"getActivatedVariation"];
     
     __weak id weakSelf = self;
-    [self.optimizelyTypedAudience.notificationCenter addActivateNotificationListener:^(OPTLYExperiment *experiment, NSString *userId, NSDictionary<NSString *, NSObject *> *attributes, OPTLYVariation *variation, NSDictionary<NSString *,NSString *> *event) {
+    [self.optimizelyTypedAudience.notificationCenter addActivateNotificationListener:^(OPTLYExperiment *experiment, NSString *userId, NSDictionary<NSString *, id> *attributes, OPTLYVariation *variation, NSDictionary<NSString *,NSString *> *event) {
         id self = weakSelf;
         NSDictionary *visitors = [(NSArray *)event[@"visitors"] firstObject];
         NSArray *_attributes = (NSArray *)visitors[@"attributes"];
@@ -1547,7 +1547,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 //Test that activate returns None when complex audience conditions do not match.
 - (void)testActivateWithAttributesComplexAudienceMismatch {
     
-    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+    NSDictionary<NSString *, id> *userAttributes = @{
                                                              @"house": @"Hufflepuff",
                                                              @"lasers": @45.5
                                                              };
@@ -1573,18 +1573,18 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 //and it's a complex audience match.
 - (void)testTrackWithAttributesComplexAudienceMatch {
     
-    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+    NSDictionary<NSString *, id> *userAttributes = @{
                                                              @"house": @"Gryffindor",
                                                              @"should_do_it": @YES
                                                              };
-    NSDictionary<NSString *, NSObject *> *expectedAttributes1 = @{
+    NSDictionary<NSString *, id> *expectedAttributes1 = @{
                                                                   @"shouldIndex": @1,
                                                                   @"type": @"custom",
                                                                   @"value": @"Gryffindor",
                                                                   @"entity_id": @"594015",
                                                                   @"key": @"house"
                                                                   };
-    NSDictionary<NSString *, NSObject *> *expectedAttributes2 = @{
+    NSDictionary<NSString *, id> *expectedAttributes2 = @{
                                                                   @"shouldIndex": @1,
                                                                   @"type": @"custom",
                                                                   @"value": @YES,
@@ -1595,7 +1595,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
     id loggerMock = OCMPartialMock((OPTLYLoggerDefault *)self.optimizelyTypedAudience.logger);
     
     __weak id weakSelf = self;
-    [self.optimizelyTypedAudience.notificationCenter addTrackNotificationListener:^(NSString * _Nonnull eventKey, NSString * _Nonnull userId, NSDictionary<NSString *, NSObject *> * _Nonnull attributes, NSDictionary * _Nonnull eventTags, NSDictionary<NSString *,NSObject *> * _Nonnull event) {
+    [self.optimizelyTypedAudience.notificationCenter addTrackNotificationListener:^(NSString * _Nonnull eventKey, NSString * _Nonnull userId, NSDictionary<NSString *, id> * _Nonnull attributes, NSDictionary * _Nonnull eventTags, NSDictionary<NSString *,NSObject *> * _Nonnull event) {
         id self = weakSelf;
         NSDictionary *visitors = [(NSArray *)event[@"visitors"] firstObject];
         NSArray *_attributes = (NSArray *)visitors[@"attributes"];
@@ -1615,7 +1615,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 //Test that track does not call dispatch_event when complex audience conditions do not match.
 - (void)testTrackWithAttributesComplexAudienceMismatch {
     
-    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+    NSDictionary<NSString *, id> *userAttributes = @{
                                                              @"house": @"Gryffindor",
                                                              @"should_do_it": @false
                                                              };
@@ -1629,7 +1629,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 
 //Test that isFeatureEnabled returns True for feature rollout with complex audience match.
 - (void)testIsFeatureEnabledInRolloutComplexAudienceMatch {
-    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+    NSDictionary<NSString *, id> *userAttributes = @{
                                                              @"house": @"...Slytherinnn...sss.",
                                                              @"favorite_ice_cream": @"matcha"
                                                              };
@@ -1639,7 +1639,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 
 //Test that isFeatureEnabled returns False for feature rollout with complex audience mismatch.
 - (void)testIsFeatureEnabledInRolloutComplexAudienceMismatch {
-    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+    NSDictionary<NSString *, id> *userAttributes = @{
                                                              @"house": @"Lannister"
                                                              };
     NSString *featureFlagKey = @"feat2";
@@ -1648,7 +1648,7 @@ static NSString * const kAttributeKeyBrowserIsDefault = @"browser_is_default";
 
 //Test that getFeatureVariableInteger return variable value with complex audience match.
 - (void)testGetFeatureVariableReturnsVariableValueComplexAudienceMatch {
-    NSDictionary<NSString *, NSObject *> *userAttributes = @{
+    NSDictionary<NSString *, id> *userAttributes = @{
                                                              @"house": @"Gryffindor",
                                                              @"lasers": @700
                                                              };

--- a/OptimizelySDKShared/OptimizelySDKShared/OPTLYClient.m
+++ b/OptimizelySDKShared/OptimizelySDKShared/OPTLYClient.m
@@ -65,7 +65,7 @@
 
 - (nullable OPTLYVariation *)activate:(NSString *)experimentKey
                       userId:(NSString *)userId
-                  attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
+                  attributes:(NSDictionary<NSString *, id> *)attributes {
     if (self.optimizely == nil) {
         [self.logger logMessage:OPTLYLoggerMessagesClientDummyOptimizelyError
                       withLevel:OptimizelyLogLevelError];
@@ -88,7 +88,7 @@
 
 - (nullable OPTLYVariation *)variation:(NSString *)experimentKey
                        userId:(NSString *)userId
-                   attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
+                   attributes:(NSDictionary<NSString *, id> *)attributes {
     if (self.optimizely == nil) {
         [self.logger logMessage:OPTLYLoggerMessagesClientDummyOptimizelyError
                       withLevel:OptimizelyLogLevelError];
@@ -135,7 +135,7 @@
 
 - (BOOL)isFeatureEnabled:(nullable NSString *)featureKey
                   userId:(nullable NSString *)userId
-              attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes {
+              attributes:(nullable NSDictionary<NSString *, id> *)attributes {
     if (self.optimizely == nil) {
         [self.logger logMessage:OPTLYLoggerMessagesClientDummyOptimizelyError
                       withLevel:OptimizelyLogLevelError];
@@ -149,7 +149,7 @@
 - (NSNumber *)getFeatureVariableBoolean:(NSString *)featureKey
                             variableKey:(NSString *)variableKey
                                  userId:(NSString *)userId
-                             attributes:(NSDictionary<NSString *, NSObject *> *)attributes {
+                             attributes:(NSDictionary<NSString *, id> *)attributes {
     if (self.optimizely == nil) {
         [self.logger logMessage:OPTLYLoggerMessagesClientDummyOptimizelyError
                       withLevel:OptimizelyLogLevelError];
@@ -166,7 +166,7 @@
 - (NSNumber *)getFeatureVariableDouble:(nullable NSString *)featureKey
                            variableKey:(nullable NSString *)variableKey
                                 userId:(nullable NSString *)userId
-                            attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes {
+                            attributes:(nullable NSDictionary<NSString *, id> *)attributes {
     if (self.optimizely == nil) {
         [self.logger logMessage:OPTLYLoggerMessagesClientDummyOptimizelyError
                       withLevel:OptimizelyLogLevelError];
@@ -184,7 +184,7 @@
 - (NSNumber *)getFeatureVariableInteger:(nullable NSString *)featureKey
                             variableKey:(nullable NSString *)variableKey
                                  userId:(nullable NSString *)userId
-                             attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes {
+                             attributes:(nullable NSDictionary<NSString *, id> *)attributes {
     if (self.optimizely == nil) {
         [self.logger logMessage:OPTLYLoggerMessagesClientDummyOptimizelyError
                       withLevel:OptimizelyLogLevelError];
@@ -199,7 +199,7 @@
 }
     
 - (NSArray<NSString *> *)getEnabledFeatures:(nullable NSString *)userId
-               attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes {
+               attributes:(nullable NSDictionary<NSString *, id> *)attributes {
     if (self.optimizely == nil) {
         [self.logger logMessage:OPTLYLoggerMessagesClientDummyOptimizelyError
                       withLevel:OptimizelyLogLevelError];
@@ -215,7 +215,7 @@
 - (NSString * _Nullable)getFeatureVariableString:(nullable NSString *)featureKey
                                      variableKey:(nullable NSString *)variableKey
                                           userId:(nullable NSString *)userId
-                                      attributes:(nullable NSDictionary<NSString *, NSObject *> *)attributes {
+                                      attributes:(nullable NSDictionary<NSString *, id> *)attributes {
     if (self.optimizely == nil) {
         [self.logger logMessage:OPTLYLoggerMessagesClientDummyOptimizelyError
                       withLevel:OptimizelyLogLevelError];
@@ -236,7 +236,7 @@
 
 - (void)track:(NSString *)eventKey
        userId:(NSString *)userId
-   attributes:(NSDictionary<NSString *, NSObject *> * )attributes {
+   attributes:(NSDictionary<NSString *, id> * )attributes {
     [self track:eventKey userId:userId attributes:attributes eventTags:nil];
 }
 
@@ -248,7 +248,7 @@
 
 - (void)track:(NSString *)eventKey
       userId:(NSString *)userId
-  attributes:(NSDictionary<NSString *, NSObject *> *)attributes
+  attributes:(NSDictionary<NSString *, id> *)attributes
    eventTags:(NSDictionary<NSString *,id> *)eventTags {
     if (self.optimizely == nil) {
         [self.logger logMessage:OPTLYLoggerMessagesClientDummyOptimizelyError


### PR DESCRIPTION
## Summary
- Change all instances of attributes and eventTags from NSDictionary<NSString*,NSObject*> to NSDictionary<NSString*,id>.

## Test plan
- All current tests have been changed to use id.  
- Wrote tests in swift to make sure it works in both environments
 
## Issues
- #381 
