### PR TITLE
Fix Universal Frameworks target membership of OPTLYNSObject+Validation

### DIFF
--- a/OptimizelySDKUniversal/OptimizelySDKUniversal.xcodeproj/project.pbxproj
+++ b/OptimizelySDKUniversal/OptimizelySDKUniversal.xcodeproj/project.pbxproj
@@ -74,6 +74,10 @@
 		C77BCFC921E4790400C59995 /* OPTLYAudienceBaseCondition.m in Sources */ = {isa = PBXBuildFile; fileRef = C77BCFC721E478A800C59995 /* OPTLYAudienceBaseCondition.m */; };
 		C77BCFCB21E4792D00C59995 /* OPTLYAudienceBaseCondition.h in Headers */ = {isa = PBXBuildFile; fileRef = C77BCFC521E4789700C59995 /* OPTLYAudienceBaseCondition.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C77BCFCC21E4792F00C59995 /* OPTLYAudienceBaseCondition.h in Headers */ = {isa = PBXBuildFile; fileRef = C77BCFC521E4789700C59995 /* OPTLYAudienceBaseCondition.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DCBAF6892239A7BE0044CC27 /* OPTLYNSObject+Validation.m in Sources */ = {isa = PBXBuildFile; fileRef = DCBAF6872239A7BE0044CC27 /* OPTLYNSObject+Validation.m */; };
+		DCBAF68A2239A7BE0044CC27 /* OPTLYNSObject+Validation.m in Sources */ = {isa = PBXBuildFile; fileRef = DCBAF6872239A7BE0044CC27 /* OPTLYNSObject+Validation.m */; };
+		DCBAF68B2239A7BE0044CC27 /* OPTLYNSObject+Validation.h in Headers */ = {isa = PBXBuildFile; fileRef = DCBAF6882239A7BE0044CC27 /* OPTLYNSObject+Validation.h */; };
+		DCBAF68C2239A7BE0044CC27 /* OPTLYNSObject+Validation.h in Headers */ = {isa = PBXBuildFile; fileRef = DCBAF6882239A7BE0044CC27 /* OPTLYNSObject+Validation.h */; };
 		EA3144E91ED7A1C100A8E555 /* OPTLYDecisionService.m in Sources */ = {isa = PBXBuildFile; fileRef = EA3144E41ED7A19700A8E555 /* OPTLYDecisionService.m */; };
 		EA3144EA1ED7A1C100A8E555 /* OPTLYExperimentBucketMapEntity.m in Sources */ = {isa = PBXBuildFile; fileRef = EA3144E61ED7A19700A8E555 /* OPTLYExperimentBucketMapEntity.m */; };
 		EA3144EB1ED7A1C100A8E555 /* OPTLYUserProfile.m in Sources */ = {isa = PBXBuildFile; fileRef = EA3144E81ED7A19700A8E555 /* OPTLYUserProfile.m */; };
@@ -407,6 +411,8 @@
 		AB5B18573E1770FC43BE1EF9 /* Pods_OptimizelySDKTVOSUniversalTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OptimizelySDKTVOSUniversalTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C77BCFC521E4789700C59995 /* OPTLYAudienceBaseCondition.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OPTLYAudienceBaseCondition.h; sourceTree = "<group>"; };
 		C77BCFC721E478A800C59995 /* OPTLYAudienceBaseCondition.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OPTLYAudienceBaseCondition.m; sourceTree = "<group>"; };
+		DCBAF6872239A7BE0044CC27 /* OPTLYNSObject+Validation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "OPTLYNSObject+Validation.m"; sourceTree = "<group>"; };
+		DCBAF6882239A7BE0044CC27 /* OPTLYNSObject+Validation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "OPTLYNSObject+Validation.h"; sourceTree = "<group>"; };
 		E55812A42A88FA30C03D74F0 /* Pods-OptimizelySDKiOSUniversalTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OptimizelySDKiOSUniversalTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-OptimizelySDKiOSUniversalTests/Pods-OptimizelySDKiOSUniversalTests.release.xcconfig"; sourceTree = "<group>"; };
 		EA3144E31ED7A19700A8E555 /* OPTLYDecisionService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OPTLYDecisionService.h; sourceTree = "<group>"; };
 		EA3144E41ED7A19700A8E555 /* OPTLYDecisionService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OPTLYDecisionService.m; sourceTree = "<group>"; };
@@ -836,6 +842,8 @@
 				EAC5F14E1E7B604C00C087B8 /* OPTLYLogger.m */,
 				EAC5F2341E7B639B00C087B8 /* OPTLYLoggerMessages.h */,
 				EAC5F14F1E7B604C00C087B8 /* OPTLYLoggerMessages.m */,
+				DCBAF6882239A7BE0044CC27 /* OPTLYNSObject+Validation.h */,
+				DCBAF6872239A7BE0044CC27 /* OPTLYNSObject+Validation.m */,
 				EAC5F2361E7B639B00C087B8 /* OPTLYNetworkService.h */,
 				EAC5F1501E7B604C00C087B8 /* OPTLYNetworkService.m */,
 				3ED0F1AF200F351E00FCFBE0 /* OPTLYNotificationCenter.h */,
@@ -1056,6 +1064,7 @@
 				EA52CA621E851CC100D4FCA0 /* OPTLYManagerBasic.h in Headers */,
 				EA52CA631E851CC100D4FCA0 /* OPTLYManagerBuilder.h in Headers */,
 				EA52CA641E851CC100D4FCA0 /* OPTLYErrorHandler.h in Headers */,
+				DCBAF68B2239A7BE0044CC27 /* OPTLYNSObject+Validation.h in Headers */,
 				EA52CA651E851CC100D4FCA0 /* OPTLYNetworkService.h in Headers */,
 				EA52CEF41E86690500D4FCA0 /* OptimizelySDKiOS.h in Headers */,
 				EA52CA6B1E851CC100D4FCA0 /* Optimizely.h in Headers */,
@@ -1120,6 +1129,7 @@
 				EA52CAEE1E851CEE00D4FCA0 /* OPTLYProjectConfigBuilder.h in Headers */,
 				EA52CAEF1E851CEE00D4FCA0 /* OPTLYQueue.h in Headers */,
 				EA52CAF01E851CEE00D4FCA0 /* OPTLYTrafficAllocation.h in Headers */,
+				DCBAF68C2239A7BE0044CC27 /* OPTLYNSObject+Validation.h in Headers */,
 				EA52CAF41E851CEE00D4FCA0 /* OPTLYDatafileManager.h in Headers */,
 				EA52CAF51E851CEE00D4FCA0 /* OPTLYDatafileManagerBuilder.h in Headers */,
 				EA52CAF61E851CEE00D4FCA0 /* OPTLYEventDispatcher.h in Headers */,
@@ -1469,6 +1479,7 @@
 				EA52C9F61E851CC100D4FCA0 /* OPTLYManagerBuilder.m in Sources */,
 				EA52C9FA1E851CC100D4FCA0 /* OPTLYEventDispatcher.m in Sources */,
 				EA52C9FB1E851CC100D4FCA0 /* OPTLYEventDispatcherBuilder.m in Sources */,
+				DCBAF6892239A7BE0044CC27 /* OPTLYNSObject+Validation.m in Sources */,
 				EA52C9FC1E851CC100D4FCA0 /* OPTLYDatafileManager.m in Sources */,
 				EA52C9FD1E851CC100D4FCA0 /* OPTLYDatafileManagerBuilder.m in Sources */,
 				EAF880D71EF1D42500143F7C /* OPTLYJSONKeyMapper.m in Sources */,
@@ -1575,6 +1586,7 @@
 				EA52CAB91E851CEE00D4FCA0 /* OPTLYEventFeature.m in Sources */,
 				EAE8C4091EC4E25600A76A2D /* OPTLYUserProfileServiceBuilder.m in Sources */,
 				EA52CABB1E851CEE00D4FCA0 /* OPTLYEventHeader.m in Sources */,
+				DCBAF68A2239A7BE0044CC27 /* OPTLYNSObject+Validation.m in Sources */,
 				EAF880B71EF1D40200143F7C /* OPTLYJSONModelClassProperty.m in Sources */,
 				EA52CABC1E851CEE00D4FCA0 /* OPTLYEventLayerState.m in Sources */,
 				EA52CABD1E851CEE00D4FCA0 /* OPTLYEventMetric.m in Sources */,


### PR DESCRIPTION
## Summary

The current universal frameworks miss the symbols defined in `OPTLYNSObject+Validation`. This includes the category method on `-[NSObject getValidString]`.

I have not commited the build results, as I was not sure what the procedure is here.

This leads to a crash like the following:
```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[NSTaggedPointerString getValidString]: unrecognized selector sent to instance 0x8310f8f42e277786'

*** First throw call stack:
(
	0   CoreFoundation                      0x0000000107b641bb __exceptionPreprocess + 331
	1   libobjc.A.dylib                     0x0000000106a13735 objc_exception_throw + 48
	2   CoreFoundation                      0x0000000107b82f44 -[NSObject(NSObject) doesNotRecognizeSelector:] + 132
	3   CoreFoundation                      0x0000000107b68ed6 ___forwarding___ + 1446
	4   CoreFoundation                      0x0000000107b6ada8 _CF_forwarding_prep_0 + 120
	5   OptimizelySDKiOS                    0x00000001060e7cbe -[Optimizely activate:userId:attributes:callback:] + 121
	6   OptimizelySDKiOS                    0x00000001060e7c11 -[Optimizely activate:userId:attributes:] + 76
	7   OptimizelySDKiOS                    0x00000001060d8cf7 -[OPTLYClient activate:userId:attributes:] + 157
	8   OptimizelySDKiOS                    0x00000001060d8c34 -[OPTLYClient activate:userId:] + 53
```

## Test plan

Follow the [Manual Install instructions](https://docs.developers.optimizely.com/full-stack/docs/install-the-sdk#section-manual-installation) and attempt to track an event.
