### PR TITLE
Update the 3.0.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The 3.0 release improves event tracking and supports additional audience targeti
 ### New Features:
 * Event tracking ([#359](https://github.com/optimizely/objective-c-sdk/pull/359)):
   * The Track method now dispatches its conversion event _unconditionally_, without first determining whether the user is targeted by a known experiment that uses the event. This may increase outbound network traffic.
-  * In Optimizely results, conversion events sent by 3.0 SDKs are automatically attributed to variations that the user has previously seen, as long as our backend has actually received the impression events for those variations.
+  * In Optimizely results, conversion events sent by 3.0 SDKs don't explicitly name the experiments and variations that are currently targeted to the user. Instead, conversions are automatically attributed to variations that the user has previously seen, as long as those variations were served via 3.0 SDKs or by other clients capable of automatic attribution, and as long as our backend actually received the impression events for those variations.
   * Altogether, this allows you to track conversion events and attribute them to variations even when you don't know all of a user's attribute values, and even if the user's attribute values or the experiment's configuration have changed such that the user is no longer affected by the experiment. As a result, **you may observe an increase in the conversion rate for previously-instrumented events.** If that is undesirable, you can reset the results of previously-running experiments after upgrading to the 3.0 SDK.
   * This will also allow you to attribute events to variations from other Optimizely projects in your account, even though those experiments don't appear in the same datafile.
   * Note that for results segmentation in Optimizely results, the user attribute values from one event are automatically applied to all other events in the same session, as long as the events in question were actually received by our backend. This behavior was already in place and is not affected by the 3.0 release.
@@ -49,6 +49,7 @@ The 3.0 release improves event tracking and supports additional audience targeti
 * Support for empty bucketing IDs when evaluating feature rollouts ([#367](https://github.com/optimizely/objective-c-sdk/pull/367)).
 
 ### Breaking Changes:
+* Conversion events sent by 3.0 SDKs don't explicitly name the experiments and variations that are currently targeted to the user, so these events are unattributed in raw events data export. You must use the new _results_ export to determine the variations to which events have been attributed.
 * Previously, notification listeners were only given string-valued user attributes because only strings could be passed into various method calls. That is no longer the case. The `ActivateListener` and `TrackListener` interfaces now receive user attributes as `NSDictionary<NSString *, NSObject *> * _Nullable` instead of  `NSDictionary<NSString *,NSString *> * _Nonnull`.
 * The Localytics integration now relies on the user profile service to attribute events to the user's variations.
 * Drops support for the `variableBoolean`, `variableDouble`, `variableInteger`, and `variableString` APIs. Please migrate to the Feature Management APIs which were introduced in the 2.x releases.


### PR DESCRIPTION
We want to _further_ clarify the event tracking changes in the 3.0 release. I'm updating the `master` branch but I won't try to update the `3.0.0` tag.

[Preview link](https://github.com/optimizely/objective-c-sdk/blob/nikhil/update-3.0.0-changelog/CHANGELOG.md)