### PR TITLE
(fix): Fixes parsing of latest datafiles in 2.1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Optimizely Objective-C SDK Changelog
 
-## [Unreleased]
-Changes that have landed but are not yet released.
-* This adds support to handle and parse both single leaf node and arraylist of audience conditions.
-
 ## 2.1.6
 January 25th, 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Optimizely Objective-C SDK Changelog
 
+## [Unreleased]
+Changes that have landed but are not yet released.
+* This adds support to handle and parse both single leaf node and arraylist of audience conditions.
+
 ## 2.1.6
 January 25th, 2019
 

--- a/OptimizelySDKCore/OptimizelySDKCore.xcodeproj/project.pbxproj
+++ b/OptimizelySDKCore/OptimizelySDKCore.xcodeproj/project.pbxproj
@@ -225,6 +225,8 @@
 		90855D0120ED254600A97BEC /* OPTLYControlAttributes.h in Headers */ = {isa = PBXBuildFile; fileRef = 90855CFC20ED237F00A97BEC /* OPTLYControlAttributes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		90855D0D20ED2E0100A97BEC /* OPTLYControlAttributes.m in Sources */ = {isa = PBXBuildFile; fileRef = 90855D0420ED2B0200A97BEC /* OPTLYControlAttributes.m */; };
 		90855D0E20ED2E0300A97BEC /* OPTLYControlAttributes.m in Sources */ = {isa = PBXBuildFile; fileRef = 90855D0420ED2B0200A97BEC /* OPTLYControlAttributes.m */; };
+		C7059863228401EE004AB16E /* V4TestDatafile.json in Resources */ = {isa = PBXBuildFile; fileRef = C7059862228401EE004AB16E /* V4TestDatafile.json */; };
+		C7059864228401EE004AB16E /* V4TestDatafile.json in Resources */ = {isa = PBXBuildFile; fileRef = C7059862228401EE004AB16E /* V4TestDatafile.json */; };
 		EA064BC71DD3FC8800DF7537 /* OPTLYQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = EA064BC51DD3FC8800DF7537 /* OPTLYQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA064BC81DD3FC8800DF7537 /* OPTLYQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = EA064BC51DD3FC8800DF7537 /* OPTLYQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EA064BC91DD3FC8800DF7537 /* OPTLYQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = EA064BC61DD3FC8800DF7537 /* OPTLYQueue.m */; };
@@ -629,6 +631,7 @@
 		A52039FD7B704890859320C4 /* Pods-OptimizelySDKCoreiOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OptimizelySDKCoreiOSTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-OptimizelySDKCoreiOSTests/Pods-OptimizelySDKCoreiOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		B333468714C0D4A8633103EF /* Pods-OptimizelySDKCoreiOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OptimizelySDKCoreiOSTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-OptimizelySDKCoreiOSTests/Pods-OptimizelySDKCoreiOSTests.release.xcconfig"; sourceTree = "<group>"; };
 		BE0C3BD9DC6186DB98A667C2 /* Pods_OptimizelySDKCoreTVOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OptimizelySDKCoreTVOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C7059862228401EE004AB16E /* V4TestDatafile.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = V4TestDatafile.json; sourceTree = "<group>"; };
 		E2E7211C032DF7A75264FDDB /* Pods-OptimizelySDKCoreTVOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OptimizelySDKCoreTVOSTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-OptimizelySDKCoreTVOSTests/Pods-OptimizelySDKCoreTVOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		EA064BC51DD3FC8800DF7537 /* OPTLYQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OPTLYQueue.h; sourceTree = "<group>"; };
 		EA064BC61DD3FC8800DF7537 /* OPTLYQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OPTLYQueue.m; sourceTree = "<group>"; };
@@ -1176,6 +1179,7 @@
 				EA2FAB981DC6FDFA00B1D81B /* test_data_25_experiments.json */,
 				EA2FAB991DC6FDFA00B1D81B /* test_data_50_experiments.json */,
 				3EF9D98F20AE424F00A9B002 /* V2TestDatafile.json */,
+				C7059862228401EE004AB16E /* V4TestDatafile.json */,
 			);
 			path = TestData;
 			sourceTree = "<group>";
@@ -1670,6 +1674,7 @@
 				EA2FABD51DC6FDFA00B1D81B /* test_data_50_experiments.json in Resources */,
 				EA2FABCF1DC6FDFA00B1D81B /* test_data_10_experiments.json in Resources */,
 				5E4C07F31DFF645C0042B1F8 /* UnsupportedVersionDatafile.json in Resources */,
+				C7059863228401EE004AB16E /* V4TestDatafile.json in Resources */,
 				3E99CF7F1FE02C2D00B16B97 /* optimizely_6372300739_v4.json in Resources */,
 				3EEC2AF220CB3D9E00D096E4 /* test_data_10_experimentsV3.json in Resources */,
 				EA2FABC91DC6FDFA00B1D81B /* BucketerTestsDatafile.json in Resources */,
@@ -1695,6 +1700,7 @@
 				EA2FABD91DC6FDFA00B1D81B /* optimizely_7519590183.json in Resources */,
 				EA2FABD61DC6FDFA00B1D81B /* test_data_50_experiments.json in Resources */,
 				EA2FABD01DC6FDFA00B1D81B /* test_data_10_experiments.json in Resources */,
+				C7059864228401EE004AB16E /* V4TestDatafile.json in Resources */,
 				3E99CF801FE02C2E00B16B97 /* optimizely_6372300739_v4.json in Resources */,
 				3EEC2AF320CB3D9E00D096E4 /* test_data_10_experimentsV3.json in Resources */,
 				5E4C07F41DFF645C0042B1F8 /* UnsupportedVersionDatafile.json in Resources */,

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYAudience.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYAudience.m
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2016, Optimizely, Inc. and contributors                        *
+ * Copyright 2016-2019, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYAudience.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYAudience.m
@@ -16,6 +16,7 @@
 
 #import "OPTLYAudience.h"
 #import "OPTLYDatafileKeys.h"
+#import "OPTLYBaseCondition.h"
 
 @implementation OPTLYAudience
 
@@ -30,14 +31,22 @@
     NSData *data = [string dataUsingEncoding:NSUTF8StringEncoding];
     
     NSError *err = nil;
-    NSArray *array = [NSJSONSerialization JSONObjectWithData:data
-                                                     options:NSJSONReadingAllowFragments
-                                                       error:&err];
+    NSArray *array;
+    id jsonObject = [NSJSONSerialization JSONObjectWithData:data
+                                                    options:NSJSONReadingAllowFragments
+                                                      error:&err];
     if (err != nil) {
         NSException *exception = [[NSException alloc] initWithName:err.domain reason:err.localizedFailureReason userInfo:@{@"Error" : err}];
         @throw exception;
     }
     
+    if ([jsonObject isKindOfClass:[NSArray class]]) {
+        array = (NSArray *)jsonObject;
+    }
+    else if ([jsonObject isKindOfClass:[NSDictionary class]] && [OPTLYBaseCondition isBaseConditionJSON:jsonObject]) {
+        array = @[OPTLYDatafileKeysOrCondition,jsonObject];
+    }
+
     self.conditions = [OPTLYCondition deserializeJSONArray:array error:&err];
     
     if (err != nil) {

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYAudienceTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYAudienceTest.m
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2016, Optimizely, Inc. and contributors                        *
+ * Copyright 2016-2019, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYAudienceTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYAudienceTest.m
@@ -21,6 +21,7 @@ static NSString * const kAudienceName = @"Android users";
 static NSString * const kAudienceConditions = @"[\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_dimension\", \"value\": \"android\"}]]]";
 static NSString * const kAudienceConditionsWithNot = @"[\"and\", [\"or\", [\"not\", [\"or\", {\"name\": \"example\", \"type\": \"custom_attribute\", \"value\": \"test\"}]]]]";
 static NSString * const kComplexAudience = @"[\"and\", [\"or\", [\"or\", {\"name\": \"attribute_or\", \"type\": \"custom_attribute\", \"value\": \"attribute_or_value1\"}, {\"name\": \"attribute_or\", \"type\": \"custom_attribute\", \"value\": \"attribute_or_value2\"}, {\"name\": \"attribute_or\", \"type\": \"custom_attribute\", \"value\": \"attribute_or_value3\"}]], [\"or\", [\"or\", {\"name\": \"attribute_and\", \"type\": \"custom_attribute\", \"value\": \"attribute_and_value1\"}]], [\"or\", [\"not\", [\"or\", {\"name\": \"attribute_not\", \"type\": \"custom_attribute\", \"value\": \"attribute_not_value\"}]]]]";
+static NSString * const kLeafAudienceCondition = @"{\"name\": \"attribute_not\", \"type\": \"custom_attribute\", \"value\": \"attribute_not_value\"}";
 
 @interface OPTLYAudienceTest : XCTestCase
 
@@ -84,6 +85,20 @@ static NSString * const kComplexAudience = @"[\"and\", [\"or\", [\"or\", {\"name
     XCTAssertFalse([audience evaluateConditionsWithAttributes:attributesFailBadAttributeNot]);
     XCTAssertFalse([audience evaluateConditionsWithAttributes:attributesFailBadAttributeOr]);
     XCTAssertFalse([audience evaluateConditionsWithAttributes:attributesFailBadAttributeAnd]);
+}
+
+- (void)testLeafAudienceCondition {
+    
+    OPTLYAudience * audience = [[OPTLYAudience alloc] initWithDictionary:@{@"id" : kAudienceId,
+                                                                           @"name" : kAudienceName,
+                                                                           @"conditions" : kLeafAudienceCondition}
+                                                                   error:nil];
+    XCTAssertNotNil(audience);
+    XCTAssertTrue([audience.conditions.firstObject isKindOfClass:[OPTLYOrCondition class]]);
+
+    NSDictionary *attributes = @{@"attribute_not" : @"attribute_not_value"};
+
+    XCTAssertTrue([audience evaluateConditionsWithAttributes:attributes]);
 }
 
 @end

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
@@ -38,6 +38,7 @@ static NSString *const kEventNameWithMultipleExperiments = @"testEventWithMultip
 
 // datafiles
 static NSString *const kV2TestDatafileName = @"V2TestDatafile";
+static NSString *const kV4TestDatafileName = @"V4TestDatafile";
 static NSString *const kBucketerTestDatafileName = @"BucketerTestsDatafile";
 
 // user IDs
@@ -161,6 +162,15 @@ static NSString * const kVariationIDForWhitelisting = @"variation4";
 // Test initializing with older V2 datafile
 - (void)testOlderV2Datafile {
     NSData *datafile = [OPTLYTestHelper loadJSONDatafileIntoDataObject:kV2TestDatafileName];
+    Optimizely *optimizely = [[Optimizely alloc] initWithBuilder:[OPTLYBuilder builderWithBlock:^(OPTLYBuilder * _Nullable builder) {
+        builder.datafile = datafile;
+    }]];
+    XCTAssertNotNil(optimizely);
+}
+
+// Test initializing with v4 datafile
+- (void)testOlderV4Datafile {
+    NSData *datafile = [OPTLYTestHelper loadJSONDatafileIntoDataObject:kV4TestDatafileName];
     Optimizely *optimizely = [[Optimizely alloc] initWithBuilder:[OPTLYBuilder builderWithBlock:^(OPTLYBuilder * _Nullable builder) {
         builder.datafile = datafile;
     }]];

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OptimizelyTest.m
@@ -169,7 +169,7 @@ static NSString * const kVariationIDForWhitelisting = @"variation4";
 }
 
 // Test initializing with v4 datafile
-- (void)testOlderV4Datafile {
+- (void)testV4Datafile {
     NSData *datafile = [OPTLYTestHelper loadJSONDatafileIntoDataObject:kV4TestDatafileName];
     Optimizely *optimizely = [[Optimizely alloc] initWithBuilder:[OPTLYBuilder builderWithBlock:^(OPTLYBuilder * _Nullable builder) {
         builder.datafile = datafile;

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/TestData/V4TestDatafile.json
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/TestData/V4TestDatafile.json
@@ -1,0 +1,1937 @@
+{
+  "version": "4",
+  "rollouts": [],
+  "anonymizeIP": true,
+  "projectId": "10431130345",
+  "variables": [],
+  "featureFlags": [],
+  "experiments": [
+    {
+      "status": "Running",
+      "key": "ab_running_exp_single_exact_match_string_audience",
+      "layerId": "10420273888",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523121",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["10413101794", "10413101795"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523121",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977673"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_untargeted",
+      "layerId": "10420273889",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523122",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523122",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977674"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_exact_match",
+      "layerId": "10420273889",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523122",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101794", "20413101795", "20413101796", "20413101797" ,"20413101798"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523122",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "103909776741"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_exists_match",
+      "layerId": "10420273890",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523123",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101799", "20413101800", "20413101801" ,"20413101802"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523123",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977675"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_lt_43_match",
+      "layerId": "10420273891",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523124",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101803", "20413101804"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523124",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977676"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_gt_41_match",
+      "layerId": "10420273892",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523125",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101805", "20413101806"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523125",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977677"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_substring_match",
+      "layerId": "10420273893",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523126",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101807"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523126",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977678"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_gt_41_and_lt_43",
+      "layerId": "10420273894",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523127",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101808"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523127",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977679"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_exact_match_missing_value",
+      "layerId": "10420273895",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523128",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["or", "20413101810", "20413101811", "20413101812", "20413101813"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523128",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977680"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_s_foo_or_s_bar",
+      "layerId": "10420273896",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523129",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101814"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523129",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977681"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_b_true_or_i_lt_43",
+      "layerId": "10420273897",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523130",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101815"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523130",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977682"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_lt_4_3_match",
+      "layerId": "10420273898",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523131",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101804"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523131",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977683"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_gt_4_1_match",
+      "layerId": "10420273899",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523132",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101806"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523132",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977684"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_gt_4_1_and_lt_4_3",
+      "layerId": "10420273900",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523133",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101809"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523133",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977685"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_exact_match",
+      "layerId": "10420273901",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523134",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101816", "20413101817", "20413101818" ,"20413101819"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523134",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977686"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_s_foo_exists_match",
+      "layerId": "10420273902",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523135",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101820"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523135",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977687"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_b_true_exists_match",
+      "layerId": "10420273903",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523136",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101821"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523136",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977688"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_i_42_exists_match",
+      "layerId": "10420273904",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523137",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101822"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523137",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977689"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_d_4_2_exists_match",
+      "layerId": "10420273905",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523138",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101823"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523138",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977690"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_lt_43_match",
+      "layerId": "10420273906",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523139",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101824"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523139",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977691"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_lt_4_3_match",
+      "layerId": "10420273907",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523140",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101825"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523140",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977692"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_gt_41_match",
+      "layerId": "10420273908",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523141",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101826"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523141",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977693"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_gt_4_1_match",
+      "layerId": "10420273909",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523142",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101827"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523142",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977694"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_substring_match",
+      "layerId": "10420273910",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523143",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101828"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523143",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977695"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_gt_41_and_lt_43",
+      "layerId": "10420273911",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523144",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101829"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523144",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977696"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_gt_4_1_and_lt_4_3",
+      "layerId": "10420273912",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523145",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101830"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523145",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977697"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_invalid_attribute_type",
+      "layerId": "10420273913",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523146",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["or", "20413101831", "20413101832"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523146",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977698"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_unknown_match_type",
+      "layerId": "10420273914",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523147",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["or", "20413101833"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523147",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977699"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_missing_match_type",
+      "layerId": "10420273915",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523148",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["20413101834"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523148",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977700"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_lt_match_null_value",
+      "layerId": "10420273916",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523149",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["or", "20413101835"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523149",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977701"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_lt_match_string_value",
+      "layerId": "10420273917",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523150",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["or", "20413101836"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523150",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977702"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_lt_match_missing_value",
+      "layerId": "10420273918",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523151",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["or", "20413101837"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523151",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977703"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_gt_match_null_value",
+      "layerId": "10420273919",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523152",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["or", "20413101838"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523151",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977704"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_gt_match_string_value",
+      "layerId": "10420273920",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523153",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["or", "20413101839"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523153",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977705"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_gt_match_missing_value",
+      "layerId": "10420273921",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523154",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["or", "20413101840"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523154",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977706"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_substring_match_missing_value",
+      "layerId": "10420273922",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523155",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["or", "20413101841"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523155",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977707"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_substring_match_null_value",
+      "layerId": "10420273923",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523156",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["or", "20413101842"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523156",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977708"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_substring_match_boolean_value",
+      "layerId": "10420273924",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523157",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["or", "20413101843"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523157",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977709"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_typed_audiences_substring_match_number_value",
+      "layerId": "10420273925",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523158",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["or", "20413101844"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523158",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977710"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_exact_foo_and_42",
+      "layerId": "10420273926",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523159",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["and", "20413101795", "20413101797"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523159",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977711"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_exact_foo_or_42",
+      "layerId": "10420273927",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523160",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["or", "20413101795", "20413101797"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523160",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977712"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_exact_foo_and__42_or_4_2",
+      "layerId": "10420273928",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523161",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["and", "20413101795", ["or", "20413101797", "20413101798"]],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523161",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977713"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_exact_foo_or_true__and__42_or_4_2",
+      "layerId": "10420273929",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523162",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["and", ["or", "20413101795", "20413101796"], ["or", "20413101797", "20413101798"]],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523162",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977714"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_exact_foo_and_true__and__42_and_4_2",
+      "layerId": "10420273929",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523162",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["and", ["and", "20413101795", "20413101796"], ["and", "20413101797", "20413101798"]],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523162",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977715"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_exact_foo_and_true__or__42_and_4_2",
+      "layerId": "10420273930",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523163",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["or", ["and", "20413101795", "20413101796"], ["and", "20413101797", "20413101798"]],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523163",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977716"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_exact_foo_and_true_and_42_and_4_2",
+      "layerId": "10420273931",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523164",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["and", "20413101795", "20413101796", "20413101797", "20413101798"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523164",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977717"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_not_foo",
+      "layerId": "10420273932",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523165",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["not", "20413101795"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523165",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977718"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_not__foo_or_42",
+      "layerId": "10420273933",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523166",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["not", ["or", "20413101795", "20413101797"]],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523166",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977719"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_not__foo_and_42",
+      "layerId": "10420273934",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523167",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["not", ["and", "20413101795", "20413101797"]],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523167",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977720"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_not_foo__and__not_42",
+      "layerId": "10420273935",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523168",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["and", ["not", "20413101795"], ["not", "20413101797"]],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523168",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977721"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_not_foo__or__not_42",
+      "layerId": "10420273936",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523169",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["or", ["not", "20413101795"], ["not", "20413101797"]],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523169",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977722"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_empty_conditions",
+      "layerId": "10420273937",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523170",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": [],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523170",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977723"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_not_foo_with_additional_audience",
+      "layerId": "10420273938",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523170",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["not", "20413101795", "20413101797"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523170",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977724"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_with_exact_foo_match_audience_id_and_empty_audience_conditions",
+      "layerId": "10420273939",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523171",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["10413101794"],
+      "audienceConditions": [],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523171",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977725"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_untyped_audience_combo_exact_foo_and_bar",
+      "layerId": "10420273940",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523172",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["and", "10413101796", "10413101797"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523172",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977726"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_missing_operand_exact_foo_or_42",
+      "layerId": "10420273941",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523173",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": ["20413101795", "20413101797"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523173",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977727"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_leaf_root",
+      "layerId": "10420273942",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523174",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "audienceConditions": "20413101795",
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523174",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977728"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_ids_unknown_audience_or_exact_foo",
+      "layerId": "10420273943",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523175",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["0000000000", "20413101795"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523175",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977729"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_unknown_audience_or_exact_foo",
+      "layerId": "10420273944",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523176",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["or", "0000000000", "20413101795"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523176",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977730"
+    },
+    {
+      "status": "Running",
+      "key": "ab_running_exp_audience_combo_unknown_audience_and_exact_foo",
+      "layerId": "10420273945",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523177",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["and", "0000000000", "20413101795"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523177",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977731"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_exact_match_missing_value",
+      "layerId": "10420273895",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523128",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["not", ["or", "20413101810", "20413101811", "20413101812", "20413101813"]],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523128",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977732"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_lt_match_null_value",
+      "layerId": "10420273916",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523149",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["not", "20413101835"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523149",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977733"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_lt_match_string_value",
+      "layerId": "10420273917",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523150",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["not", "20413101836"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523150",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977734"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_lt_match_missing_value",
+      "layerId": "10420273918",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523151",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["not", "20413101837"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523151",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977735"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_gt_match_null_value",
+      "layerId": "10420273919",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523152",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["not", "20413101838"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523151",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977736"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_gt_match_string_value",
+      "layerId": "10420273920",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523153",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["not", "20413101839"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523153",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977737"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_gt_match_missing_value",
+      "layerId": "10420273921",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523154",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["not", "20413101840"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523154",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977738"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_substring_match_missing_value",
+      "layerId": "10420273922",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523155",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["not", "20413101841"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523155",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977739"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_substring_match_null_value",
+      "layerId": "10420273923",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523156",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["not", "20413101842"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523156",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977740"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_substring_match_boolean_value",
+      "layerId": "10420273924",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523157",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["not", "20413101843"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523157",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977741"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_substring_match_number_value",
+      "layerId": "10420273925",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523158",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["not", "20413101844"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523158",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977742"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_invalid_attribute_type",
+      "layerId": "10420273913",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523146",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["not", ["or", "20413101831", "20413101832"]],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523146",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977743"
+    },
+    {
+      "status": "Running",
+      "key": "negated_ab_running_exp_typed_audiences_unknown_match_type",
+      "layerId": "10420273914",
+      "trafficAllocation": [
+        {
+          "entityId": "10416523147",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": ["$opt_dummy_audience"],
+      "audienceConditions": ["not", "20413101833"],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10416523147",
+          "key": "all_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10390977744"
+    }
+  ],
+  "audiences": [
+    {
+      "id": "10413101794",
+      "conditions": "[\"and\", [\"or\", [\"or\", {\"type\": \"custom_attribute\", \"name\": \"string_attribute\", \"value\": \"exact_match\"}]]]",
+      "name": "untyped_single_condition_exact_string_match"
+    },
+    {
+      "id": "10413101795",
+      "_comment_about_condition_format": "Note: pre-3.0 Java SDKs cannot parse and evaluate leaves at the root of this condition tree. App backend accommodates those SDKs by wrapping the leaves in parents. (OASIS-3718)",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"string_attribute\", \"match\": \"exact\", \"value\": \"leaf_root\"}",
+      "name": "untyped_single_condition_leaf_root"
+    },
+    {
+      "id": "10413101796",
+      "conditions": "[\"and\", [\"or\", [\"or\", {\"type\": \"custom_attribute\", \"name\": \"s_foo\", \"value\": \"foo\"}]]]",
+      "name": "untyped_single_condition_exact_foo_string_match"
+    },
+    {
+      "id": "10413101797",
+      "conditions": "[\"and\", [\"or\", [\"or\", {\"type\": \"custom_attribute\", \"name\": \"s_bar\", \"value\": \"bar\"}]]]",
+      "name": "untyped_single_condition_exact_bar_string_match"
+    },
+    {
+      "_comment": "Dummy audience that is overridden by a typedAudience with the same id",
+      "id": "20413101798",
+      "conditions": "[\"and\", [\"or\", [\"or\", {\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"match\": \"exact\", \"value\": \"$opt_dummy_value\"}]]]",
+      "name": "dummy_audience_overridden_by_typed_audience"
+    },
+    {
+      "_comment": "Dummy audience that is targeted by audienceIds for experiments with backwards-incompatible audienceConditions",
+      "id": "$opt_dummy_audience",
+      "conditions": "[\"and\", [\"or\", [\"or\", {\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"match\": \"exact\", \"value\": \"$opt_dummy_value\"}]]]",
+      "name": "dummy_audience"
+    }
+  ],
+  "typedAudiences": [
+    {
+      "id": "20413101794",
+      "conditions": { "type": "custom_attribute", "name": "s_foo", "match": "exact", "value": "leaf_root" },
+      "name": "single_condition_leaf_root"
+    },
+    {
+      "id": "20413101795",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "exact", "value": "foo" } ] ] ],
+      "name": "single_condition_exact_string_match"
+    },
+    {
+      "id": "20413101796",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "b_true", "match": "exact", "value": true } ] ] ],
+      "name": "single_condition_exact_boolean_match"
+    },
+    {
+      "id": "20413101797",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "exact", "value": 42 } ] ] ],
+      "name": "single_condition_exact_int_match"
+    },
+    {
+      "id": "20413101798",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "exact", "value": 4.2 } ] ] ],
+      "name": "single_condition_exact_double_match"
+    },
+    {
+      "id": "20413101799",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "exists" } ] ] ],
+      "name": "single_condition_exists_string_match"
+    },
+    {
+      "id": "20413101800",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "b_true", "match": "exists" } ] ] ],
+      "name": "single_condition_exists_boolean_match"
+    },
+    {
+      "id": "20413101801",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "exists" } ] ] ],
+      "name": "single_condition_exists_int_match"
+    },
+    {
+      "id": "20413101802",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "exists" } ] ] ],
+      "name": "single_condition_exists_double_match"
+    },
+    {
+      "id": "20413101803",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "lt", "value": 43 } ] ] ],
+      "name": "single_condition_lt_int_match"
+    },
+    {
+      "id": "20413101804",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "lt", "value": 4.3 } ] ] ],
+      "name": "single_condition_lt_double_match"
+    },
+    {
+      "id": "20413101805",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "gt", "value": 41 } ] ] ],
+      "name": "single_condition_gt_int_match"
+    },
+    {
+      "id": "20413101806",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "gt", "value": 4.1 } ] ] ],
+      "name": "single_condition_gt_double_match"
+    },
+    {
+      "id": "20413101807",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "substring", "value": "foo" } ] ] ],
+      "name": "single_condition_substring_match"
+    },
+    {
+      "id": "20413101808",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "lt", "value": 43 } ] ], [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "gt", "value": 41 } ] ] ],
+      "name": "multiple_conditions_integer_range_match"
+    },
+    {
+      "id": "20413101809",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "lt", "value": 4.3 } ] ], [ "or", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "gt", "value": 4.1 } ] ] ],
+      "name": "multiple_conditions_double_range_match"
+    },
+    {
+      "id": "20413101810",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "exact" } ] ] ],
+      "name": "single_condition_exact_match_missing_value"
+    },
+    {
+      "id": "20413101811",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "b_true", "match": "exact" } ] ] ],
+      "name": "single_condition_exact_match_missing_value"
+    },
+    {
+      "id": "20413101812",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "exact" } ] ] ],
+      "name": "single_condition_exact_match_missing_value"
+    },
+    {
+      "id": "20413101813",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "exact" } ] ] ],
+      "name": "single_condition_exact_match_missing_value"
+    },
+    {
+      "id": "20413101814",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "exact", "value": "foo" }, { "type": "custom_attribute", "name": "s_bar", "match": "exact", "value": "bar" } ] ] ],
+      "name": "multiple_or_string_conditions_exact_match"
+    },
+    {
+      "id": "20413101815",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "b_true", "match": "exact", "value": true }, { "type": "custom_attribute", "name": "i_42", "match": "lt", "value": 43 } ] ] ],
+      "name": "multiple_or_conditions_mixed_types"
+    },
+    {
+      "id": "20413101816",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "exact", "value": "foo" } ] ] ] ],
+      "name": "negated_single_condition_exact_string_match"
+    },
+    {
+      "id": "20413101817",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "b_true", "match": "exact", "value": true } ] ] ] ],
+      "name": "negated_single_condition_exact_boolean_match"
+    },
+    {
+      "id": "20413101818",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "exact", "value": 42 } ] ] ] ],
+      "name": "negated_single_condition_exact_int_match"
+    },
+    {
+      "id": "20413101819",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "exact", "value": 4.2 } ] ] ] ],
+      "name": "negated_single_condition_exact_double_match"
+    },
+    {
+      "id": "20413101820",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "exists" } ] ] ] ],
+      "name": "negated_single_condition_exists_string_match"
+    },
+    {
+      "id": "20413101821",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "b_true", "match": "exists" } ] ] ] ],
+      "name": "negated_single_condition_exists_boolean_match"
+    },
+    {
+      "id": "20413101822",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "exists" } ] ] ] ],
+      "name": "negated_single_condition_exists_int_match"
+    },
+    {
+      "id": "20413101823",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "exists" } ] ] ] ],
+      "name": "negated_single_condition_exists_double_match"
+    },
+    {
+      "id": "20413101824",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "lt", "value": 43 } ] ] ] ],
+      "name": "negated_single_condition_lt_int_match"
+    },
+    {
+      "id": "20413101825",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "lt", "value": 4.3 } ] ] ] ],
+      "name": "negated_single_condition_lt_double_match"
+    },
+    {
+      "id": "20413101826",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "gt", "value": 41 } ] ] ] ],
+      "name": "negated_single_condition_gt_int_match"
+    },
+    {
+      "id": "20413101827",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "gt", "value": 4.1 } ] ] ] ],
+      "name": "negated_single_condition_gt_double_match"
+    },
+    {
+      "id": "20413101828",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "substring", "value": "foo" } ] ] ] ],
+      "name": "negated_single_condition_substring_match"
+    },
+    {
+      "id": "20413101829",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "lt", "value": 43 } ] ], [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "gt", "value": 41 } ] ] ] ] ],
+      "name": "negated_multiple_conditions_integer_range_match"
+    },
+    {
+      "id": "20413101830",
+      "conditions": [ "and", [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "lt", "value": 4.3 } ] ], [ "or", [ "not", [ "or", { "type": "custom_attribute", "name": "d_4_2", "match": "gt", "value": 4.1 } ] ] ] ] ],
+      "name": "negated_multiple_conditions_double_range_match"
+    },
+    {
+      "id": "20413101831",
+      "conditions": [ "and", [ "or", [ "or", { "type": "unknown", "name": "s_foo", "match": "exact" } ] ] ],
+      "name": "single_condition_exact_match_string_unknown_attribute_type"
+    },
+    {
+      "id": "20413101832",
+      "conditions": [ "and", [ "or", [ "or", { "name": "s_foo", "match": "exact" } ] ] ],
+      "name": "single_condition_exact_match_string_missing_attribute_type"
+    },
+    {
+      "id": "20413101833",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "unknown" } ] ] ],
+      "name": "single_condition_unknown_match_string"
+    },
+    {
+      "id": "20413101834",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "value": "foo" } ] ] ],
+      "name": "single_condition_missing_match_string"
+    },
+    {
+      "id": "20413101835",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "value": null, "match": "lt" } ] ] ],
+      "name": "single_condition_lt_match_null_value"
+    },
+    {
+      "id": "20413101836",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "value": "41", "match": "lt" } ] ] ],
+      "name": "single_condition_lt_match_string_value"
+    },
+    {
+      "id": "20413101837",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "lt" } ] ] ],
+      "name": "single_condition_lt_match_missing_value"
+    },
+    {
+      "id": "20413101838",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "value": null, "match": "gt" } ] ] ],
+      "name": "single_condition_gt_match_null_value"
+    },
+    {
+      "id": "20413101839",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "value": "41", "match": "gt" } ] ] ],
+      "name": "single_condition_gt_match_string_value"
+    },
+    {
+      "id": "20413101840",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "i_42", "match": "gt" } ] ] ],
+      "name": "single_condition_gt_match_missing_value"
+    },
+    {
+      "id": "20413101841",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "substring" } ] ] ],
+      "name": "single_condition_substring_match_missing_value"
+    },
+    {
+      "id": "20413101842",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "substring", "value": null } ] ] ],
+      "name": "single_condition_substring_match_null_value"
+    },
+    {
+      "id": "20413101843",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "substring", "value": true } ] ] ],
+      "name": "single_condition_substring_match_boolean_value"
+    },
+    {
+      "id": "20413101844",
+      "conditions": [ "and", [ "or", [ "or", { "type": "custom_attribute", "name": "s_foo", "match": "substring", "value": 400 } ] ] ],
+      "name": "single_condition_substring_match_number_value"
+    }
+  ],
+  "groups": [],
+  "attributes": [
+    {
+      "id": "10401066170",
+      "key": "string_attribute"
+    },
+    {
+      "id": "10401066171",
+      "key": "s_foo"
+    },
+    {
+      "id": "10401066172",
+      "key": "b_true"
+    },
+    {
+      "id": "10401066172",
+      "key": "i_42"
+    },
+    {
+      "id": "10401066173",
+      "key": "d_4_2"
+    },
+    {
+      "id": "10401066174",
+      "key": "s_bar"
+    },
+    {
+      "id": "10401066175",
+      "key": "b_false"
+    },
+    {
+      "id": "10401066176",
+      "key": "i_43"
+    },
+    {
+      "id": "10401066177",
+      "key": "d_4_3"
+    }
+  ],
+  "accountId": "10367498574",
+  "events": [
+    {
+      "experimentIds": [
+        "10390977673"
+      ],
+      "id": "10404198135",
+      "key": "event_single_targeted_exp"
+    },
+    {
+      "experimentIds": [
+        "10390977674"
+      ],
+      "id": "10404198136",
+      "key": "event_single_untargeted_exp"
+    }
+  ],
+  "revision": "241"
+}


### PR DESCRIPTION
## Summary
- This adds support to handle and parse both single leaf node and arraylist of audience conditions.
