### PR TITLE
(fix):When a ephemeral session configuration causes an exception, catch try background or return nil.

### DIFF
--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYHTTPRequestManager.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYHTTPRequestManager.m
@@ -47,7 +47,7 @@ static NSString * const kHTTPHeaderFieldValueApplicationJSON = @"application/jso
     }
     @catch (NSException *e) {
         OPTLYLogError(e.description);
-        return self.backgroundSession;
+        //return self.backgroundSession;
     }
     
     return ephemeralSession;

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYHTTPRequestManager.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYHTTPRequestManager.m
@@ -38,10 +38,32 @@ static NSString * const kHTTPHeaderFieldValueApplicationJSON = @"application/jso
 @implementation OPTLYHTTPRequestManager
 
 - (NSURLSession *)session {
-    NSURLSession *ephemeralSession = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
-    ephemeralSession.configuration.TLSMinimumSupportedProtocol = kTLSProtocol12;
+    NSURLSession *ephemeralSession = nil;
+    
+    @try {
+        ephemeralSession = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
+        ephemeralSession.configuration.TLSMinimumSupportedProtocol = kTLSProtocol12;
 
+    }
+    @catch (NSException *e) {
+        OPTLYLogError(e.description);
+        return self.backgroundSession;
+    }
+    
     return ephemeralSession;
+}
+
+- (NSURLSession *)backgroundSession {
+    NSURLSession *backgroundSession = nil;
+    
+    @try {
+        backgroundSession = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:@"backgroundFlushEvent"]];
+        backgroundSession.configuration.TLSMinimumSupportedProtocol = kTLSProtocol12;
+    }
+    @catch (NSException *e) {
+        OPTLYLogError(e.description);
+    }
+    return backgroundSession;
 }
 
 # pragma mark - Object Initializers

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYHTTPRequestManagerTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYHTTPRequestManagerTest.m
@@ -185,7 +185,7 @@ static NSInteger const kBackoffRetryInterval = 1;
             XCTAssert(false);
         }
         XCTAssert(true);
-        [self swizzleBackConfig];
+        [self swizzleConfig];
     }];
 }
 
@@ -382,12 +382,6 @@ static NSInteger const kBackoffRetryInterval = 1;
     Method method = class_getClassMethod(NSURLSessionConfiguration.class, @selector(ephemeralSessionConfiguration));
     Method swizzle_method = class_getClassMethod(NSURLSessionConfiguration.class, @selector(getEphemeral));
     
-    method_exchangeImplementations(method, swizzle_method);
-}
-- (void)swizzleBackConfig {
-    Method method = class_getClassMethod(NSURLSessionConfiguration.class, @selector(ephemeralSessionConfiguration));
-    Method swizzle_method = class_getClassMethod(NSURLSessionConfiguration.class, @selector(getEphemeral));
-
     method_exchangeImplementations(method, swizzle_method);
 }
 @end

--- a/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYHTTPRequestManagerTest.m
+++ b/OptimizelySDKCore/OptimizelySDKCoreTests/OPTLYHTTPRequestManagerTest.m
@@ -16,6 +16,7 @@
 
 #import <XCTest/XCTest.h>
 #import <OHHTTPStubs/OHHTTPStubs.h>
+#import <OCMock/OCMock.h>
 #import "OPTLYHTTPRequestManager.h"
 #import "OPTLYTestHelper.h"
 
@@ -158,6 +159,33 @@ static NSInteger const kBackoffRetryInterval = 1;
         if (error) {
             NSLog(@"Timeout error for POSTWithParameters: %@", error);
         }
+    }];
+}
+
+- (void)testPOSTWithException
+{
+
+    
+    [self swizzleConfig];
+    
+    OPTLYHTTPRequestManager *requestManager = [OPTLYHTTPRequestManager new];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Wait for POSTWithParameters to timeout."];
+    // we are not expecting this to be filled.  the session should just disappear.
+    expectation.inverted = true;
+    
+    [requestManager POSTWithParameters:self.parameters url:self.testURL completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        // we never get here
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:5.0 handler:^(NSError *error) {
+        if (error) {
+            NSLog(@"Error Occurred: %@", error);
+            XCTAssert(false);
+        }
+        XCTAssert(true);
+        [self swizzleBackConfig];
     }];
 }
 
@@ -350,4 +378,26 @@ static NSInteger const kBackoffRetryInterval = 1;
     XCTAssertTrue(requestManager.retryAttemptTest == kRetryAttempts+1, @"Invalid number of retries.");
     XCTAssertTrue([requestManager.delaysTest isEqualToArray:self.expectedDelays], @"Invalid delays set for backoff retry.");
 }
+- (void)swizzleConfig {
+    Method method = class_getClassMethod(NSURLSessionConfiguration.class, @selector(ephemeralSessionConfiguration));
+    Method swizzle_method = class_getClassMethod(NSURLSessionConfiguration.class, @selector(getEphemeral));
+    
+    method_exchangeImplementations(method, swizzle_method);
+}
+- (void)swizzleBackConfig {
+    Method method = class_getClassMethod(NSURLSessionConfiguration.class, @selector(ephemeralSessionConfiguration));
+    Method swizzle_method = class_getClassMethod(NSURLSessionConfiguration.class, @selector(getEphemeral));
+
+    method_exchangeImplementations(method, swizzle_method);
+}
+@end
+
+@interface NSURLSessionConfiguration(OPTLYSTubs)
+    + (NSURLSessionConfiguration *)getEphemeral;
+@end
+@implementation NSURLSessionConfiguration(OPTLYSTubs)
+    + (NSURLSessionConfiguration *)getEphemeral {
+        [NSException raise:@"problem" format:@"problem"];
+        return nil;
+    }
 @end


### PR DESCRIPTION
…of test for this.

## Summary
This wraps the ephemeral session creation with a try catch and logs an error.  if it fails, it returns nil which will in turn cause the session to be nil which will in turn make the NSURLSessionUploadTask nil in which case resume will be a noop and the completion handler would never be called.  This should result in a failed session being a noop.

## Test plan
Here is where the magic of objective-c happens. I wrote a unit test by swizzling URLSessionConfiguration to raise an exception.  I then swizzle it back after the test completes.

I discovered with this test that attempting to use a background session can cause a different kind of exception.  So, in order to avoid any such exception, we simply return nil and the event is not sent.  It will then be sent on the next attempt to send events.
