### PR TITLE
(fix): rename protocols in OPTLYJSONModel to avoid conflicts with JSONModel in client apps

### DIFF
--- a/OptimizelySDKCore/OPTLYJSONModel/OPTLYJSONModel/OPTLYJSONModel/OPTLYJSONModel.h
+++ b/OptimizelySDKCore/OPTLYJSONModel/OPTLYJSONModel/OPTLYJSONModel/OPTLYJSONModel.h
@@ -34,10 +34,6 @@ lastPathComponent], __LINE__, [NSString stringWithFormat:(s), ##__VA_ARGS__] )
 #endif
 /////////////////////////////////////////////////////////////////////////////////////////////
 
-//DEPRECATED_ATTRIBUTE
-//@protocol ConvertOnDemand
-//@end
-
 DEPRECATED_ATTRIBUTE
 @protocol OPTLYIndex
 @end

--- a/OptimizelySDKCore/OPTLYJSONModel/OPTLYJSONModel/OPTLYJSONModel/OPTLYJSONModel.h
+++ b/OptimizelySDKCore/OPTLYJSONModel/OPTLYJSONModel/OPTLYJSONModel/OPTLYJSONModel.h
@@ -34,12 +34,12 @@ lastPathComponent], __LINE__, [NSString stringWithFormat:(s), ##__VA_ARGS__] )
 #endif
 /////////////////////////////////////////////////////////////////////////////////////////////
 
-DEPRECATED_ATTRIBUTE
-@protocol ConvertOnDemand
-@end
+//DEPRECATED_ATTRIBUTE
+//@protocol ConvertOnDemand
+//@end
 
 DEPRECATED_ATTRIBUTE
-@protocol Index
+@protocol OPTLYIndex
 @end
 
 #pragma mark - Property Protocols
@@ -50,7 +50,7 @@ DEPRECATED_ATTRIBUTE
  * @property (strong, nonatomic) NSString&lt;Ignore&gt; *propertyName;
  *
  */
-@protocol Ignore
+@protocol OPTLYIgnore
 @end
 
 /**
@@ -66,7 +66,7 @@ DEPRECATED_ATTRIBUTE
 /**
  * Make all objects compatible to avoid compiler warnings
  */
-@interface NSObject (OPTLYJSONModelPropertyCompatibility) <OPTLYOptional, Ignore>
+@interface NSObject (OPTLYJSONModelPropertyCompatibility) <OPTLYOptional, OPTLYIgnore>
 @end
 
 /////////////////////////////////////////////////////////////////////////////////////////////

--- a/OptimizelySDKCore/OPTLYJSONModel/OPTLYJSONModel/OPTLYJSONModel/OPTLYJSONModel.m
+++ b/OptimizelySDKCore/OPTLYJSONModel/OPTLYJSONModel/OPTLYJSONModel/OPTLYJSONModel.m
@@ -609,7 +609,7 @@ static OPTLYJSONKeyMapper* globalKeyMapper = nil;
 
                     if ([protocolName isEqualToString:@"OPTLYOptional"]) {
                         p.isOptional = YES;
-                    } else if([protocolName isEqualToString:@"Index"]) {
+                    } else if([protocolName isEqualToString:@"OPTLYIndex"]) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
                         p.isIndex = YES;
@@ -621,7 +621,7 @@ static OPTLYJSONKeyMapper* globalKeyMapper = nil;
                                                  p.name,
                                                  OBJC_ASSOCIATION_RETAIN // This is atomic
                                                  );
-                    } else if([protocolName isEqualToString:@"Ignore"]) {
+                    } else if([protocolName isEqualToString:@"OPTLYIgnore"]) {
                         p = nil;
                     } else {
                         p.protocol = protocolName;

--- a/OptimizelySDKCore/OPTLYJSONModelTests/Models/Headers/ConcurrentReposModel.h
+++ b/OptimizelySDKCore/OPTLYJSONModelTests/Models/Headers/ConcurrentReposModel.h
@@ -39,7 +39,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-@property (strong, nonatomic) NSString<Index>* name;
+@property (strong, nonatomic) NSString<OPTLYIndex>* name;
 #pragma GCC diagnostic pop
 
 @end

--- a/OptimizelySDKCore/OPTLYJSONModelTests/Models/Headers/GitHubKeyMapRepoModel.h
+++ b/OptimizelySDKCore/OPTLYJSONModelTests/Models/Headers/GitHubKeyMapRepoModel.h
@@ -31,7 +31,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-@property (assign, nonatomic) NSString<Index>* name;
+@property (assign, nonatomic) NSString<OPTLYIndex>* name;
 #pragma GCC diagnostic pop
 
 @end

--- a/OptimizelySDKCore/OPTLYJSONModelTests/Models/Headers/GitHubRepoModel.h
+++ b/OptimizelySDKCore/OPTLYJSONModelTests/Models/Headers/GitHubRepoModel.h
@@ -38,7 +38,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-@property (strong, nonatomic) NSString<Index>* name;
+@property (strong, nonatomic) NSString<OPTLYIndex>* name;
 #pragma GCC diagnostic pop
 
 @end

--- a/OptimizelySDKCore/OPTLYJSONModelTests/Models/Headers/OptionalPropModel.h
+++ b/OptimizelySDKCore/OPTLYJSONModelTests/Models/Headers/OptionalPropModel.h
@@ -29,7 +29,7 @@
 
 @property (assign, nonatomic) int fillerNumber;
 @property (strong, nonatomic) NSString<OPTLYOptional>* notRequredProperty;
-@property (strong, nonatomic) NSString<Ignore>* ignoredProperty;
+@property (strong, nonatomic) NSString<OPTLYIgnore>* ignoredProperty;
 @property (assign, nonatomic) CGPoint notRequiredPoint;
 
 +(BOOL)propertyIsOptional:(NSString*)propertyName;

--- a/OptimizelySDKCore/OPTLYJSONModelTests/Models/Headers/PostModel.h
+++ b/OptimizelySDKCore/OPTLYJSONModelTests/Models/Headers/PostModel.h
@@ -28,7 +28,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-@property (strong, nonatomic) NSString<Index>* id;
+@property (strong, nonatomic) NSString<OPTLYIndex>* id;
 #pragma GCC diagnostic pop
 
 @property (strong, nonatomic) NSString<OPTLYOptional>* name;

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYAudience.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYAudience.m
@@ -23,7 +23,7 @@
 
 @interface OPTLYAudience()
 /// String representation of the conditions
-@property (nonatomic, strong) NSString<Ignore> *conditionsString;
+@property (nonatomic, strong) NSString<OPTLYIgnore> *conditionsString;
 @end
 
 @implementation OPTLYAudience

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYBaseCondition.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYBaseCondition.m
@@ -22,7 +22,7 @@
 
 @interface OPTLYBaseCondition()
 /// String representation of self
-@property (nonatomic, strong) NSString<Ignore> *stringRepresentation;
+@property (nonatomic, strong) NSString<OPTLYIgnore> *stringRepresentation;
 @end
 
 @implementation OPTLYBaseCondition

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYExperiment.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYExperiment.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_END
 /// The experiment's status.
 @property (nonatomic, strong, nonnull) NSString *status;
 /// The group ID the experiment belongs to.
-@property (nonatomic, strong, nullable) NSString<Ignore> *groupId;
+@property (nonatomic, strong, nullable) NSString<OPTLYIgnore> *groupId;
 /// The experiment's traffic allocations.
 @property (nonatomic, strong, nonnull) NSArray<OPTLYTrafficAllocation *><OPTLYTrafficAllocation> *trafficAllocations;
 /// An array of audience Ids for the experiment

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYExperiment.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYExperiment.m
@@ -24,12 +24,12 @@ NSString * const OPTLYExperimentStatusRunning = @"Running";
 @interface OPTLYExperiment()
 /// A mapping of an experiment's variation's ID to the matching variation.
 /// @{NSString *variationId : OPTLYVariation *variation}
-@property (nonatomic, strong) NSDictionary<Ignore> *variationIdToVariationMap;
+@property (nonatomic, strong) NSDictionary<OPTLYIgnore> *variationIdToVariationMap;
 /// A mapping of an experiment's variation's Key to the matching variation.
 /// @{NSString *variationKey : OPTLYVariation *variation}
-@property (nonatomic, strong) NSDictionary<Ignore> *variationKeyToVariationMap;
+@property (nonatomic, strong) NSDictionary<OPTLYIgnore> *variationKeyToVariationMap;
 /// A JSON String containing the expirement's audience conditions
-@property (nonatomic, strong) NSString<Ignore> *conditionsString;
+@property (nonatomic, strong) NSString<OPTLYIgnore> *conditionsString;
 @end
 
 @implementation OPTLYExperiment

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYFeatureFlag.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYFeatureFlag.m
@@ -23,7 +23,7 @@
 
 @interface OPTLYFeatureFlag()
 
-@property (nonatomic, strong) NSDictionary<NSString *, OPTLYFeatureVariable *><Ignore> *featureVariableKeyToFeatureVariableMap;
+@property (nonatomic, strong) NSDictionary<NSString *, OPTLYFeatureVariable *><OPTLYIgnore> *featureVariableKeyToFeatureVariableMap;
 
 @end
 

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYProjectConfig.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYProjectConfig.h
@@ -63,14 +63,14 @@ NS_ASSUME_NONNULL_END
 
 /// a comprehensive list of experiments that includes experiments being whitelisted (in Groups)
 @property (nonatomic, strong, nullable) NSArray<OPTLYExperiment *><OPTLYExperiment, OPTLYOptional> *allExperiments;
-@property (nonatomic, strong, nullable) id<OPTLYLogger, Ignore> logger;
-@property (nonatomic, strong, nullable) id<OPTLYErrorHandler, Ignore> errorHandler;
-@property (nonatomic, strong, readonly, nullable) id<OPTLYUserProfileService, Ignore> userProfileService;
+@property (nonatomic, strong, nullable) id<OPTLYLogger, OPTLYIgnore> logger;
+@property (nonatomic, strong, nullable) id<OPTLYErrorHandler, OPTLYIgnore> errorHandler;
+@property (nonatomic, strong, readonly, nullable) id<OPTLYUserProfileService, OPTLYIgnore> userProfileService;
 
 /// Returns the client type (e.g., objective-c-sdk, ios-sdk, tvos-sdk)
-@property (nonatomic, strong, readonly, nonnull) NSString<Ignore> *clientEngine;
+@property (nonatomic, strong, readonly, nonnull) NSString<OPTLYIgnore> *clientEngine;
 /// Returns the client version number
-@property (nonatomic, strong, readonly, nonnull) NSString<Ignore> *clientVersion;
+@property (nonatomic, strong, readonly, nonnull) NSString<OPTLYIgnore> *clientVersion;
 /// List of Optimizely Feature Flags objects
 @property (nonatomic, strong, nonnull) NSArray<OPTLYFeatureFlag *><OPTLYFeatureFlag, OPTLYOptional> *featureFlags;
 /// List of Optimizely Rollouts objects

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYProjectConfig.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYProjectConfig.m
@@ -38,20 +38,20 @@ static NSArray *supportedDatafileVersions = nil;
 
 @interface OPTLYProjectConfig()
 
-@property (nonatomic, strong) NSDictionary<NSString *, OPTLYAudience *><Ignore> *audienceIdToAudienceMap;
-@property (nonatomic, strong) NSDictionary<NSString *, OPTLYEvent *><Ignore> *eventKeyToEventMap;
-@property (nonatomic, strong) NSDictionary<NSString *, NSString *><Ignore> *eventKeyToEventIdMap;
-@property (nonatomic, strong) NSDictionary<NSString *, OPTLYExperiment *><Ignore> *experimentIdToExperimentMap;
-@property (nonatomic, strong) NSDictionary<NSString *, OPTLYExperiment *><Ignore> *experimentKeyToExperimentMap;
-@property (nonatomic, strong) NSDictionary<NSString *, OPTLYFeatureFlag *><Ignore> *featureFlagKeyToFeatureFlagMap;
-@property (nonatomic, strong) NSDictionary<NSString *, OPTLYRollout *><Ignore> *rolloutIdToRolloutMap;
-@property (nonatomic, strong) NSDictionary<NSString *, NSArray *><Ignore> *experimentIdToFeatureIdsMap;
-@property (nonatomic, strong) NSDictionary<NSString *, NSString *><Ignore> *experimentKeyToExperimentIdMap;
-@property (nonatomic, strong) NSDictionary<NSString *, OPTLYGroup *><Ignore> *groupIdToGroupMap;
-@property (nonatomic, strong) NSDictionary<NSString *, OPTLYAttribute *><Ignore> *attributeKeyToAttributeMap;
-//@property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, NSString *>><Ignore> *forcedVariationMap;
+@property (nonatomic, strong) NSDictionary<NSString *, OPTLYAudience *><OPTLYIgnore> *audienceIdToAudienceMap;
+@property (nonatomic, strong) NSDictionary<NSString *, OPTLYEvent *><OPTLYIgnore> *eventKeyToEventMap;
+@property (nonatomic, strong) NSDictionary<NSString *, NSString *><OPTLYIgnore> *eventKeyToEventIdMap;
+@property (nonatomic, strong) NSDictionary<NSString *, OPTLYExperiment *><OPTLYIgnore> *experimentIdToExperimentMap;
+@property (nonatomic, strong) NSDictionary<NSString *, OPTLYExperiment *><OPTLYIgnore> *experimentKeyToExperimentMap;
+@property (nonatomic, strong) NSDictionary<NSString *, OPTLYFeatureFlag *><OPTLYIgnore> *featureFlagKeyToFeatureFlagMap;
+@property (nonatomic, strong) NSDictionary<NSString *, OPTLYRollout *><OPTLYIgnore> *rolloutIdToRolloutMap;
+@property (nonatomic, strong) NSDictionary<NSString *, NSArray *><OPTLYIgnore> *experimentIdToFeatureIdsMap;
+@property (nonatomic, strong) NSDictionary<NSString *, NSString *><OPTLYIgnore> *experimentKeyToExperimentIdMap;
+@property (nonatomic, strong) NSDictionary<NSString *, OPTLYGroup *><OPTLYIgnore> *groupIdToGroupMap;
+@property (nonatomic, strong) NSDictionary<NSString *, OPTLYAttribute *><OPTLYIgnore> *attributeKeyToAttributeMap;
+//@property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, NSString *>><OPTLYIgnore> *forcedVariationMap;
 //    userId --> experimentId --> variationId
-@property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableDictionary *><Ignore> *forcedVariationMap;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSMutableDictionary *><OPTLYIgnore> *forcedVariationMap;
 
 @end
 
@@ -158,15 +158,15 @@ static NSArray *supportedDatafileVersions = nil;
         if (![OPTLYUserProfileServiceUtility conformsToOPTLYUserProfileServiceProtocol:[builder.userProfileService class]]) {
             [builder.logger logMessage:OPTLYErrorHandlerMessagesUserProfileInvalid withLevel:OptimizelyLogLevelWarning];
         } else {
-            _userProfileService = (id<OPTLYUserProfileService, Ignore>)builder.userProfileService;
+            _userProfileService = (id<OPTLYUserProfileService, OPTLYIgnore>)builder.userProfileService;
         }
     }
     
     _clientEngine = builder.clientEngine;
     _clientVersion = builder.clientVersion;
     
-    _errorHandler = (id<OPTLYErrorHandler, Ignore>)builder.errorHandler;
-    _logger = (id<OPTLYLogger, Ignore>)builder.logger;
+    _errorHandler = (id<OPTLYErrorHandler, OPTLYIgnore>)builder.errorHandler;
+    _logger = (id<OPTLYLogger, OPTLYIgnore>)builder.logger;
     return self;
 }
 
@@ -455,7 +455,7 @@ static NSArray *supportedDatafileVersions = nil;
     return _experimentKeyToExperimentIdMap;
 }
 
-- (NSDictionary<NSString *,NSArray *><Ignore> *)experimentIdToFeatureIdsMap
+- (NSDictionary<NSString *,NSArray *><OPTLYIgnore> *)experimentIdToFeatureIdsMap
 {
     if (!_experimentIdToFeatureIdsMap) {
         _experimentIdToFeatureIdsMap = [self generateExperimentIdToFeatureIdsMap];

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYVariation.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYVariation.m
@@ -20,7 +20,7 @@
 
 @interface OPTLYVariation()
 /// A mapping of Feature Variable IDs to Variable Usages constructed during the initialization of Variation objects from the list of Variable Usages.
-@property (nonatomic, strong) NSDictionary<NSString *, OPTLYVariableUsage *><Ignore> *variableIdToVariableUsageMap;
+@property (nonatomic, strong) NSDictionary<NSString *, OPTLYVariableUsage *><OPTLYIgnore> *variableIdToVariableUsageMap;
 @end
 
 @implementation OPTLYVariation


### PR DESCRIPTION
## Summary
- When apps use own copy of JSONModel library, it can have name conflicts with OPTLYJSONModel
- For Xcode 10.1 or older, they're ignored, so no issue.
- When clients upgrade Xcode to 10.2+, it creates a compile error.

This fix changes the protocol names of potential conflicts (Ignore -> OPTLYIgnore, Index -> OPTLYIndex) and removes deprecated ConvertOnDemand.

## Test plan
- Run all existing tests to confirm it does not break any JSON models in OptimizelySDKCore 

## Issues
- OASIS-5046
