### PR TITLE
(fix): get_variation input validation fixes.

### DIFF
--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYLoggerMessages.h
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYLoggerMessages.h
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2017-2019, Optimizely, Inc. and contributors                   *
+ * Copyright 2017-2020, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -31,6 +31,8 @@ extern NSString *const OPTLYLoggerMessagesConversionFailure;
 extern NSString *const OPTLYLoggerMessagesUserIdInvalid;
 extern NSString *const OPTLYLoggerMessagesActivateExperimentKeyEmpty;
 extern NSString *const OPTLYLoggerMessagesActivateExperimentKeyInvalid;
+extern NSString *const OPTLYLoggerMessagesGetVariationExperimentKeyEmpty;
+extern NSString *const OPTLYLoggerMessagesGetVariationExperimentKeyInvalid;
 extern NSString *const OPTLYLoggerMessagesTrackEventKeyEmpty;
 extern NSString *const OPTLYLoggerMessagesTrackEventKeyInvalid;
 extern NSString *const OPTLYLoggerMessagesTrackEventNoAssociation;

--- a/OptimizelySDKCore/OptimizelySDKCore/OPTLYLoggerMessages.m
+++ b/OptimizelySDKCore/OptimizelySDKCore/OPTLYLoggerMessages.m
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2017-2019, Optimizely, Inc. and contributors                   *
+ * Copyright 2017-2020, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -27,6 +27,8 @@ NSString *const OPTLYLoggerMessagesConversionFailure = @"[OPTIMIZELY] No valid e
 NSString *const OPTLYLoggerMessagesUserIdInvalid = @"[OPTIMIZELY] User ID cannot be nil or an empty string.";
 NSString *const OPTLYLoggerMessagesActivateExperimentKeyEmpty = @"[OPTIMIZELY] Experiment Key cannot be nil or an empty string.";
 NSString *const OPTLYLoggerMessagesActivateExperimentKeyInvalid = @"[OPTIMIZELY] Experiment not found for Key %@.";
+NSString *const OPTLYLoggerMessagesGetVariationExperimentKeyEmpty = @"[OPTIMIZELY] Experiment Key cannot be nil or an empty string.";
+NSString *const OPTLYLoggerMessagesGetVariationExperimentKeyInvalid = @"[OPTIMIZELY] Experiment not found for Key %@.";
 NSString *const OPTLYLoggerMessagesTrackEventKeyEmpty = @"[OPTIMIZELY] Event Key cannot be nil or an empty string.";
 NSString *const OPTLYLoggerMessagesTrackEventKeyInvalid = @"[OPTIMIZELY] Event not found for Key %@.";
 NSString *const OPTLYLoggerMessagesTrackEventNoAssociation = @"[OPTIMIZELY] Event key %@ is not associated with any experiment.";


### PR DESCRIPTION
## Summary
- Fixed issue for experimentKey and user_id validation for get_variation.
- Notification was fired in every getVariation case where experimentKey was invalid.

## TestPlan
- Run testcases and here's the result.
https://travis-ci.com/optimizely/fullstack-sdk-compatibility-suite/builds/144164489
