### PR TITLE
chore: fix xcode 12 build failure

### DIFF
--- a/OptimizelySDKCore.podspec
+++ b/OptimizelySDKCore.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage                = "http://developers.optimizely.com/server/reference/index.html?language=objectivec"
   s.license                 = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
   s.author                  = { "Optimizely" => "support@optimizely.com" }
-  s.ios.deployment_target   = "8.0"
+  s.ios.deployment_target   = "9.0"
   s.tvos.deployment_target  = "9.0"
   s.source                  = {
     :git => "https://github.com/optimizely/objective-c-sdk.git",

--- a/OptimizelySDKDatafileManager.podspec
+++ b/OptimizelySDKDatafileManager.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage                = "http://developers.optimizely.com/server/reference/index.html?language=objectivec"
   s.license                 = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
   s.author                  = { "Optimizely" => "support@optimizely.com" }
-  s.ios.deployment_target   = "8.0"
+  s.ios.deployment_target   = "9.0"
   s.tvos.deployment_target  = "9.0"
   s.source                  = {
     :git => "https://github.com/optimizely/objective-c-sdk.git",
@@ -17,4 +17,5 @@ Pod::Spec.new do |s|
   s.requires_arc            = true
   s.xcconfig                = { 'GCC_PREPROCESSOR_DEFINITIONS' => "OPTIMIZELY_SDK_VERSION=@\\\"#{s.version}\\\"" }
   s.dependency 'OptimizelySDKShared', "3.1.4"
+  s.dependency 'OptimizelySDKCore', "3.1.4"
 end

--- a/OptimizelySDKEventDispatcher.podspec
+++ b/OptimizelySDKEventDispatcher.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage                = "http://developers.optimizely.com/server/reference/index.html?language=objectivec"
   s.license                 = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
   s.author                  = { "Optimizely" => "support@optimizely.com" }
-  s.ios.deployment_target   = "8.0"
+  s.ios.deployment_target   = "9.0"
   s.tvos.deployment_target  = "9.0"
   s.source                  = {
     :git => "https://github.com/optimizely/objective-c-sdk.git",
@@ -17,4 +17,5 @@ Pod::Spec.new do |s|
   s.requires_arc            = true
   s.xcconfig                = { 'GCC_PREPROCESSOR_DEFINITIONS' => "OPTIMIZELY_SDK_VERSION=@\\\"#{s.version}\\\"" }
   s.dependency 'OptimizelySDKShared', "3.1.4"
+  s.dependency 'OptimizelySDKCore', "3.1.4"
 end

--- a/OptimizelySDKShared.podspec
+++ b/OptimizelySDKShared.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage                = "http://developers.optimizely.com/server/reference/index.html?language=objectivec"
   s.license                 = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
   s.author                  = { "Optimizely" => "support@optimizely.com" }
-  s.ios.deployment_target   = "8.0"
+  s.ios.deployment_target   = "9.0"
   s.tvos.deployment_target  = "9.0"
   s.source                  = {
     :git => "https://github.com/optimizely/objective-c-sdk.git",

--- a/OptimizelySDKTVOS.podspec
+++ b/OptimizelySDKTVOS.podspec
@@ -19,4 +19,6 @@ Pod::Spec.new do |s|
   s.dependency 'OptimizelySDKEventDispatcher', "3.1.4"
   s.dependency 'OptimizelySDKUserProfileService', "3.1.4"
   s.dependency 'OptimizelySDKDatafileManager', "3.1.4"
+  s.dependency 'OptimizelySDKShared', "3.1.4"
+  s.dependency 'OptimizelySDKCore', "3.1.4"
 end

--- a/OptimizelySDKUserProfileService.podspec
+++ b/OptimizelySDKUserProfileService.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage                = "http://developers.optimizely.com/server/reference/index.html?language=objectivec"
   s.license                 = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
   s.author                  = { "Optimizely" => "support@optimizely.com" }
-  s.ios.deployment_target   = "8.0"
+  s.ios.deployment_target   = "9.0"
   s.tvos.deployment_target  = "9.0"
   s.source                  = {
     :git => "https://github.com/optimizely/objective-c-sdk.git",
@@ -17,4 +17,5 @@ Pod::Spec.new do |s|
   s.requires_arc            = true
   s.xcconfig                = { 'GCC_PREPROCESSOR_DEFINITIONS' => "OPTIMIZELY_SDK_USER_PROFILE_VERSION=@\\\"#{s.version}\\\"" }
   s.dependency 'OptimizelySDKShared', "3.1.4"
+  s.dependency 'OptimizelySDKCore', "3.1.4"
 end

--- a/OptimizelySDKiOS.podspec
+++ b/OptimizelySDKiOS.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage                = "http://developers.optimizely.com/server"
   s.license                 = { :type => "Apache License, Version 2.0", :file => "LICENSE" }
   s.author                  = "Optimizely"
-  s.ios.deployment_target   = "8.0"
+  s.ios.deployment_target   = "9.0"
   s.source                  = {
     :git => "https://github.com/optimizely/objective-c-sdk.git",
     :tag => "v"+s.version.to_s
@@ -18,4 +18,6 @@ Pod::Spec.new do |s|
   s.dependency 'OptimizelySDKEventDispatcher', "3.1.4"
   s.dependency 'OptimizelySDKUserProfileService', "3.1.4"
   s.dependency 'OptimizelySDKDatafileManager', "3.1.4"
+  s.dependency 'OptimizelySDKShared', "3.1.4"
+  s.dependency 'OptimizelySDKCore', "3.1.4"
 end


### PR DESCRIPTION
## Summary
- Xcode 12 fails building SDK modules with CocoaPods (fails at linking)
- Explicitly add secondary dependencies into podspec
